### PR TITLE
[OMCT-68] commonTabs 컴포넌트 구현

### DIFF
--- a/src/components/common/Tabs/index.tsx
+++ b/src/components/common/Tabs/index.tsx
@@ -1,0 +1,44 @@
+import { ReactElement } from 'react';
+import { Tabs, TabList, TabPanels, Tab, TabPanel, TabsProps } from '@chakra-ui/react';
+
+interface TabsData {
+  label: string;
+  content: string | ReactElement;
+}
+interface CommonTabsProps {
+  tabsType?: 'soft-rounded' | 'line';
+  isFitted?: TabsProps['isFitted'];
+  tabsData: TabsData[];
+}
+
+const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line' }: CommonTabsProps) => {
+  return (
+    <Tabs isFitted={isFitted} variant={tabsType} size="sm">
+      <TabList>
+        {tabsData.map((tab, index) => (
+          <Tab
+            color="blue.900"
+            bg="none"
+            _selected={
+              tabsType === 'line'
+                ? { color: 'blue.300', borderColor: 'blue.300' }
+                : { color: 'white', bg: 'blue.300' }
+            }
+            key={index}
+          >
+            {tab.label}
+          </Tab>
+        ))}
+      </TabList>
+      <TabPanels>
+        {tabsData.map((tab, index) => (
+          <TabPanel p={4} key={index}>
+            {tab.content}
+          </TabPanel>
+        ))}
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export default CommonTabs;

--- a/src/components/common/Tabs/index.tsx
+++ b/src/components/common/Tabs/index.tsx
@@ -9,14 +9,19 @@ interface CommonTabsProps {
   tabsType?: 'soft-rounded' | 'line';
   isFitted?: TabsProps['isFitted'];
   tabsData: TabsData[];
+  onClick?: () => void;
 }
 
-const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line' }: CommonTabsProps) => {
+const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line', onClick }: CommonTabsProps) => {
+  const handleOnClick = () => {
+    onClick && onClick();
+  };
   return (
     <Tabs isFitted={isFitted} variant={tabsType} size="sm">
       <TabList>
         {tabsData.map((tab, index) => (
           <Tab
+            onClick={handleOnClick}
             color="blue.900"
             bg="none"
             _selected={

--- a/src/components/common/Tabs/index.tsx
+++ b/src/components/common/Tabs/index.tsx
@@ -13,7 +13,7 @@ interface CommonTabsProps {
 }
 
 const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line', onClick }: CommonTabsProps) => {
-  const handleOnClick = () => {
+  const handleClick = () => {
     onClick && onClick();
   };
   return (
@@ -21,7 +21,7 @@ const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line', onClick }: C
       <TabList>
         {tabsData.map((tab, index) => (
           <Tab
-            onClick={handleOnClick}
+            onClick={handleClick}
             color="blue.900"
             bg="none"
             _selected={


### PR DESCRIPTION
## 구현(수정) 내용
commonTabs 컴포넌트를 구현했습니다!
아직 미흡한게 있는것같아서 정리해서 추후에 한번에 수정하도록하겠습니다! (정리는 지라 이슈내용에 하겠습니다. 확인부탁드립니당!)

## 스크린샷

https://github.com/bucket-back/bucket-back-frontend/assets/104294861/6f182a6c-f5af-4c84-a01c-75b0287c38ea

## PR 포인트 및 궁금한 점

> By default, the Tabs component renders all tabs content to the DOM, meaning that invisible tabs are still rendered but are hidden by styles.
> 
> If you want to defer rendering of each tab until that tab is selected, you can use the isLazy prop. This is useful if your tabs require heavy performance, or make network calls on mount that should only happen when the component is displayed.

차크라 탭 컴포넌트에서 자체적으로 lazy라는 기능을 제공해주는것같은데
탭에 따라 불러오는 내용이 많아질수록 렌더링이 늦어질수도 있으니 lazy를 적용해보는것도 좋을것같습니다!🧐

그리고 로그인 여부에따라 버튼 보여주기(내가 올린 투표, 참여한 투표) => isDisabled로 처리할까했는데 그렇게되면 너무 단절된느낌이라 클릭하면 로그인여부 확인한다음에 로그인페이지로 넘어가는게 좋을것같습니다??