### PR TITLE
[Omct 75] 브라우저에 Service worker 등록

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "prettier": "^3.0.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
+  },
+  "msw": {
+    "workerDirectory": "public"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,22 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import { ChakraProvider } from '@chakra-ui/react';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ChakraProvider>
-      <App />
-    </ChakraProvider>
-  </React.StrictMode>
-);
+async function deferRender() {
+  if (process.env.NODE_ENV !== 'development') {
+    return;
+  }
+
+  const { worker } = await import('./mocks/browser');
+
+  return worker.start();
+}
+
+deferRender().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ChakraProvider>
+        <App />
+      </ChakraProvider>
+    </React.StrictMode>
+  );
+});

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handler } from './handler';
+
+export const worker = setupWorker(...handler);

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from 'msw';
+
+// interface UserInfo {
+//   email: string;
+//   password: number;
+//   nickname: string;
+// }
+
+const baseMemberUrl = '/api/members';
+
+export const handler = [
+  http.post(`${baseMemberUrl}/signup`, async ({ request }) => {
+    // 제대로 들어왔는지 확인
+    const userInfo = await request.json();
+    console.log(userInfo);
+    return new HttpResponse(null, 200);
+  }),
+];


### PR DESCRIPTION
## 구현(수정) 내용
msw가 [Service worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)를 이용해서 구현되었는데
이거를 브라우저에 등록하는 로직을 짜봤습니다!
merge가 되면 이 명령어를 `npx msw init public/ --save` 입력하셔야합니다!
하시면 package.json,public 폴더에 mockServiceWorker.js 파일이 생성이 됩니다!

## 스크린샷
<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/10b00078-6dec-41fb-b88e-c1688a5534bf">


## PR 포인트 및 궁금한 점
아직 배우고 있는 단계여서 코드가 깔끔하지 않습니다ㅠㅠㅠ
