### PR TITLE
[OMCT-101] CommonDivider 컴포넌트 구현 및 commitlint 룰 추가

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
+    "subject-case": [0],
     "type-enum": [
       2,
       "always",

--- a/src/components/common/Divider/index.tsx
+++ b/src/components/common/Divider/index.tsx
@@ -1,0 +1,16 @@
+import { Divider } from '@chakra-ui/react';
+
+interface CommonDividerProps {
+  size: 'sm' | 'lg';
+}
+
+const sizes = {
+  sm: 'none',
+  lg: 'thick',
+};
+
+const CommonDivider = ({ size }: CommonDividerProps) => {
+  return <Divider width="inherit" borderWidth={sizes[size]} />;
+};
+
+export default CommonDivider;


### PR DESCRIPTION
## 구현(수정) 내용
CommonDivider 컴포넌트를 구현했습니다.  
사용방법은 `size` prop에 `sm` 혹은 `lg`를 할당하면 됩니다.
`sm`은 1px이고 `lg`는 10px입니다. 
저희 프로젝트에서 수직은 사용하지 않아 추가하지 않았습니다.

추가로 commit 메시지에 파스칼케이스를 사용할 경우 에러가 뜨는 현상이 발생해서 룰을 추가했습니다.

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
