### PR TITLE
[OMCT-103] CommonSlider 컴포넌트 구현

### DIFF
--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -1,0 +1,18 @@
+import { Slider, SliderTrack, SliderFilledTrack, SliderThumb } from '@chakra-ui/react';
+
+interface CommonSliderProps {
+  onChange: (value: number) => void;
+}
+
+const CommonSlider = ({ onChange }: CommonSliderProps) => {
+  return (
+    <Slider defaultValue={2.5} min={0} max={5} step={0.5} onChange={(value) => onChange(value)}>
+      <SliderTrack>
+        <SliderFilledTrack bg="blue.300" />
+      </SliderTrack>
+      <SliderThumb boxSize={5} />
+    </Slider>
+  );
+};
+
+export default CommonSlider;


### PR DESCRIPTION
## 구현(수정) 내용
CommonSlider 컴포넌트를 구현했습니다.
사용법은 `onChange` prop에 useState의 업데이트 함수를 넣어주면 됩니다.
기본 값으로 `2.5`가 들어가있고 범위는 최소 `0`부터 최대 `5`까지 입니다.
그리고 `0.5`씩 증가/감소됩니다.
리뷰에 점수를 줄때만 사용하기에 이렇게 구현하게 됐습니다. 

```typescript
const [state, setState] = useState(2.5);

return (
  <>
    <div>{state}</div>
    <CommonSlider onChange={setState} />
  </>
);
```

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
