### PR TITLE
[OMCT-115] CommonBadge 컴포넌트 구현

### DIFF
--- a/src/components/common/Badge/index.tsx
+++ b/src/components/common/Badge/index.tsx
@@ -1,0 +1,63 @@
+import { Badge, Box } from '@chakra-ui/react';
+import { FaCrown } from 'react-icons/fa6';
+
+const LEVEL_COLOR = {
+  FONT: {
+    1: 'gray.800',
+    2: 'pink.800',
+    3: 'blue.800',
+    4: 'teal.800',
+    5: 'green.800',
+    6: 'yellow.800',
+    7: 'purple.800',
+    8: 'blue.800',
+    9: 'red.900',
+    10: 'red.600',
+  },
+  BACKGROUND: {
+    1: 'gray.200',
+    2: 'pink.100',
+    3: 'blue.100',
+    4: 'teal.100',
+    5: 'green.100',
+    6: 'orange.100',
+    7: 'purple.300',
+    8: 'cyan.400',
+    9: 'red.400',
+    10: 'yellow.300',
+  },
+};
+
+interface CommonBadgeProps {
+  type: 'level' | 'adopt' | 'vote';
+  levelNumber?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  count?: number;
+}
+
+const CommonBadge = ({ type, levelNumber, count }: CommonBadgeProps) => {
+  const badge = {
+    level: levelNumber && (
+      <Badge
+        color={LEVEL_COLOR.FONT[levelNumber]}
+        bgColor={LEVEL_COLOR.BACKGROUND[levelNumber]}
+      >{`LV. ${levelNumber}`}</Badge>
+    ),
+    adopt: (
+      <Badge w="2.8rem" color="purple.800" bgColor="purple.100">
+        <Box display="flex" alignItems="center" gap="4px">
+          채택
+          <FaCrown />
+        </Box>
+      </Badge>
+    ),
+    vote: (
+      <Badge color="blue.900" bgColor="blue.100">
+        {count}명 참여
+      </Badge>
+    ),
+  };
+
+  return <>{badge[type]}</>;
+};
+
+export default CommonBadge;


### PR DESCRIPTION
## 구현(수정) 내용
CommonBadge 컴포넌트를 구현했습니다.
`adopt` 타입은 채택, `level` 타입은 레벨, `vote` 타입은 투표에 사용됩니다.
`levelNumber`는 1 ~ 10까지 넣을 수 있고 `count`에는 숫자를 넣으면 됩니다.

```javascript
<CommonBadge type="adopt" />
<CommonBadge type="level" levelNumber={1} />
<CommonBadge type="vote" count={100} />
```

## 스크린샷
<img width="391" alt="스크린샷 2023-10-31 오후 5 07 52" src="https://github.com/bucket-back/bucket-back-frontend/assets/40534414/15014c3e-fc05-4da3-9604-a257662369d2">

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
