### PR TITLE
[OMCT-114] CommonTextarea 컴포넌트 구현

### DIFF
--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -1,11 +1,10 @@
-import { FormControl, Textarea, FormErrorMessage, FormLabel } from '@chakra-ui/react';
-import { useFormContext, RegisterOptions } from 'react-hook-form';
+import { FormControl, Textarea, FormErrorMessage, FormLabel, forwardRef } from '@chakra-ui/react';
+import { FieldError } from 'react-hook-form';
 
 interface CommonTextareaProps {
   placeholder: string;
-  name: string;
-  registerOptions: RegisterOptions;
   label?: string;
+  error?: FieldError;
   size: keyof typeof TEXTAREA_SIZE;
 }
 
@@ -15,33 +14,22 @@ const TEXTAREA_SIZE = {
   base: { width: '21.9375rem', height: '14.375rem' },
 };
 
-const CommonTextarea = ({
-  placeholder,
-  name,
-  label,
-  registerOptions,
-  size,
-}: CommonTextareaProps) => {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
-
-  return (
-    <FormControl isInvalid={!!errors[name]} isRequired={!!registerOptions.required}>
-      <FormLabel>{label}</FormLabel>
-      <Textarea
-        id={name}
-        size="sm"
-        isInvalid={!!errors[name]}
-        _focusVisible={{ boxShadow: 'none', outline: 'none' }}
-        placeholder={placeholder}
-        {...TEXTAREA_SIZE[size]}
-        {...register(name, registerOptions)}
-      />
-      {errors[name] && <FormErrorMessage>{errors[name]?.message as string}</FormErrorMessage>}
-    </FormControl>
-  );
-};
+const CommonTextarea = forwardRef(
+  ({ placeholder, label, size, error, ...props }: CommonTextareaProps, ref) => {
+    return (
+      <FormControl isInvalid={Boolean(error?.message)}>
+        <FormLabel>{label}</FormLabel>
+        <Textarea
+          size="sm"
+          placeholder={placeholder}
+          ref={ref}
+          {...TEXTAREA_SIZE[size]}
+          {...props}
+        />
+        {error?.message && <FormErrorMessage>{error.message}</FormErrorMessage>}
+      </FormControl>
+    );
+  }
+);
 
 export default CommonTextarea;

--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -6,10 +6,10 @@ interface CommonTextareaProps {
   name: string;
   registerOptions: RegisterOptions;
   label?: string;
-  size: 'xs' | 'sm' | 'base';
+  size: keyof typeof TEXTAREA_SIZE;
 }
 
-const TextareaSize = {
+const TEXTAREA_SIZE = {
   xs: { width: '20.5rem', height: '5.8125rem' },
   sm: { width: '21.9375rem', height: '9.875rem' },
   base: { width: '21.9375rem', height: '14.375rem' },
@@ -36,7 +36,7 @@ const CommonTextarea = ({
         isInvalid={!!errors[name]}
         _focusVisible={{ boxShadow: 'none', outline: 'none' }}
         placeholder={placeholder}
-        {...TextareaSize[size]}
+        {...TEXTAREA_SIZE[size]}
         {...register(name, registerOptions)}
       />
       {errors[name] && <FormErrorMessage>{errors[name]?.message as string}</FormErrorMessage>}

--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -1,0 +1,47 @@
+import { FormControl, Textarea, FormErrorMessage, FormLabel } from '@chakra-ui/react';
+import { useFormContext, RegisterOptions } from 'react-hook-form';
+
+interface CommonTextareaProps {
+  placeholder: string;
+  name: string;
+  registerOptions: RegisterOptions;
+  label?: string;
+  size: 'xs' | 'sm' | 'base';
+}
+
+const TextareaSize = {
+  xs: { width: '20.5rem', height: '5.8125rem' },
+  sm: { width: '21.9375rem', height: '9.875rem' },
+  base: { width: '21.9375rem', height: '14.375rem' },
+};
+
+const CommonTextarea = ({
+  placeholder,
+  name,
+  label,
+  registerOptions,
+  size,
+}: CommonTextareaProps) => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
+
+  return (
+    <FormControl isInvalid={!!errors[name]} isRequired={!!registerOptions.required}>
+      <FormLabel>{label}</FormLabel>
+      <Textarea
+        id={name}
+        size="sm"
+        isInvalid={!!errors[name]}
+        _focusVisible={{ boxShadow: 'none', outline: 'none' }}
+        placeholder={placeholder}
+        {...TextareaSize[size]}
+        {...register(name, registerOptions)}
+      />
+      {errors[name] && <FormErrorMessage>{errors[name]?.message as string}</FormErrorMessage>}
+    </FormControl>
+  );
+};
+
+export default CommonTextarea;


### PR DESCRIPTION
## 구현(수정) 내용
Common textarea 컴포넌트를 구현했습니다.

**사용 예시**
```
<form onSubmit={handleSubmit(onSubmit)}>
  <CommonTextarea
    size="sm"
    placeholder="내용을 입력해주세요"
    {...register('textarea', {
      required: 'This is required',
      minLength: { value: 4, message: 'Minimum length should be 4' },
    })}
    error={errors.textarea}
  />
  <Input type="submit" />
</form>

```

## 스크린샷

https://github.com/bucket-back/bucket-back-frontend/assets/104294861/958a0a2c-89cf-4b35-8100-ed2043679972



## PR 포인트 및 궁금한 점
FormControl, FormLabel, FormErrorMessage 컴포넌트는 해당 링크를 참고하여 사용하였습니다! [리액트 훅폼과 차크라ui](https://chakra-ui.com/getting-started/with-hook-form)
useFormContext와 FormProvider를 사용하여 Textarea 컴포넌트를 분리하였습니다!