### PR TITLE
[OMCT-107] CommonIcon 컴포넌트 구현

### DIFF
--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -30,7 +30,7 @@ import {
   FaRegRectangleList,
 } from 'react-icons/fa6';
 
-const icons = {
+const ICONS = {
   trashcan: FaRegTrashCan,
   chevronLeft: FaChevronLeft,
   chevronRight: FaChevronRight,
@@ -62,13 +62,13 @@ const icons = {
 };
 
 interface CommonIconProps {
-  type: keyof typeof icons;
+  type: keyof typeof ICONS;
   size?: string;
   color?: string;
 }
 
 const CommonIcon = ({ type, size, color }: CommonIconProps) => {
-  return <Icon as={icons[type]} boxSize={size} color={color} />;
+  return <Icon as={ICONS[type]} boxSize={size} color={color} />;
 };
 
 export default CommonIcon;

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -1,0 +1,74 @@
+import { Icon } from '@chakra-ui/react';
+import {
+  FaRegTrashCan,
+  FaChevronLeft,
+  FaChevronRight,
+  FaChevronDown,
+  FaHeart,
+  FaRegHeart,
+  FaMagnifyingGlass,
+  FaPen,
+  FaCube,
+  FaCubes,
+  FaBasketShopping,
+  FaBagShopping,
+  FaRegFaceGrin,
+  FaEye,
+  FaEyeSlash,
+  FaArrowUp,
+  FaPlus,
+  FaRegStar,
+  FaStar,
+  FaRegCommentDots,
+  FaCircleExclamation,
+  FaCircleCheck,
+  FaRegCircleXmark,
+  FaEllipsisVertical,
+  FaCrown,
+  FaHouse,
+  FaBriefcase,
+  FaRegRectangleList,
+} from 'react-icons/fa6';
+
+const icons = {
+  trashcan: FaRegTrashCan,
+  chevronLeft: FaChevronLeft,
+  chevronRight: FaChevronRight,
+  chevronDown: FaChevronDown,
+  heart: FaRegHeart,
+  fillHeart: FaHeart,
+  search: FaMagnifyingGlass,
+  pen: FaPen,
+  cube: FaCube,
+  cubes: FaCubes,
+  basket: FaBasketShopping,
+  bag: FaBagShopping,
+  my: FaRegFaceGrin,
+  eye: FaEye,
+  eyeSlash: FaEyeSlash,
+  arrowUp: FaArrowUp,
+  plus: FaPlus,
+  star: FaRegStar,
+  fillStar: FaStar,
+  comment: FaRegCommentDots,
+  circleExclamation: FaCircleExclamation,
+  circleCheck: FaCircleCheck,
+  circleXmark: FaRegCircleXmark,
+  ellipsis: FaEllipsisVertical,
+  crown: FaCrown,
+  home: FaHouse,
+  inventory: FaBriefcase,
+  feed: FaRegRectangleList,
+};
+
+interface CommonIconProps {
+  type: keyof typeof icons;
+  size?: string;
+  color?: string;
+}
+
+const CommonIcon = ({ type, size, color }: CommonIconProps) => {
+  return <Icon as={icons[type]} boxSize={size} color={color} />;
+};
+
+export default CommonIcon;


### PR DESCRIPTION
## 구현(수정) 내용
CommonIcon 컴포넌트를 구현했습니다.
사용법은 아래와 같습니다.
```javascript
<CommonIcon type="crown" color="blue.300" size="1rem" />
```

## 스크린샷
타입은 아래를 보시고 넣으시면 됩니다.
  
![스크린샷 2023-10-31 오후 11 18 07](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/da8df359-9a65-4f50-9f87-362aee72f424)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
