### PR TITLE
[OMCT-113]  CommonText 컴포넌트 구현 및 util 함수 정의

### DIFF
--- a/src/components/common/Text/index.tsx
+++ b/src/components/common/Text/index.tsx
@@ -2,17 +2,13 @@ import { Heading, Text } from '@chakra-ui/react';
 import conformText from '../../../utils/conformText';
 
 interface CommonTextProps {
-  type: string;
+  type: keyof typeof TEXT_TYPE;
   color: string;
   noOfLines: number | number[];
   children: string;
 }
 
-interface TextType {
-  [key: string]: { fontSize: string; weight: number };
-}
-
-const TEXT_TYPE: TextType = {
+const TEXT_TYPE = {
   strongTitle: { fontSize: '3rem', weight: 700 },
   normalTitle: { fontSize: '1.5rem', weight: 700 },
   smallTitle: { fontSize: '1.25rem', weight: 700 },

--- a/src/components/common/Text/index.tsx
+++ b/src/components/common/Text/index.tsx
@@ -1,0 +1,42 @@
+import { Heading, Text } from '@chakra-ui/react';
+import conformText from '../../../utils/conformText';
+
+interface CommonTextProps {
+  type: string;
+  color: string;
+  noOfLines: number | number[];
+  children: string;
+}
+
+interface TextType {
+  [key: string]: { fontSize: string; weight: number };
+}
+
+const TEXT_TYPE: TextType = {
+  strongTitle: { fontSize: '3rem', weight: 700 },
+  normalTitle: { fontSize: '1.5rem', weight: 700 },
+  smallTitle: { fontSize: '1.25rem', weight: 700 },
+  strongInfo: { fontSize: '1rem', weight: 700 },
+  subStrongInfo: { fontSize: '1.125rem', weight: 400 },
+  normalInfo: { fontSize: '0.875rem', weight: 500 },
+  boldNormalInfo: { fontSize: '0.75rem', weight: 600 },
+  smallInfo: { fontSize: '0.75rem', weight: 400 },
+};
+
+const CommonText = ({ type, color, noOfLines, children }: CommonTextProps) => {
+  return (
+    <>
+      {conformText(type, 'title') ? (
+        <Heading color={color} noOfLines={noOfLines} fontFamily="Inter" {...TEXT_TYPE[type]}>
+          {children}
+        </Heading>
+      ) : (
+        <Text color={color} noOfLines={noOfLines} {...TEXT_TYPE[type]}>
+          {children}
+        </Text>
+      )}
+    </>
+  );
+};
+
+export default CommonText;

--- a/src/utils/conformText.ts
+++ b/src/utils/conformText.ts
@@ -1,0 +1,5 @@
+const conformText = (temp: string, conform: string) => {
+  return temp.toLowerCase().includes(conform);
+};
+
+export default conformText;


### PR DESCRIPTION
## 구현(수정) 내용
CommonText 컴포넌트 구현
-  color,noOfLines(몇줄을 보여줄지),type(title,info에 종류),children(아무 문장을 입력하기 때문에 선언) 를 prorp를 받습니다!
-  유틸함수를 구현해서 title일때는 heading 컴포넌트로 나오게 구현했습니다!

conformText 유틸함수 구현
- type에 따라서 heading을 줘야할지 고민을 하다가 구현했습니다!

## 스크린샷


<img width="793" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/16dbda45-b2e1-47f0-a622-a896758f0fc6">

## PR 포인트 및 궁금한 점
- fontFamily는 아직 넣지 않았는데 전역으로 해보고 안되면 바로 추가하겠습니다!
- type에 이름이 어색하면 바로 수정하겠습니다!