### PR TITLE
[OMCT-109] CommonIconButton 컴포넌트 구현

### DIFF
--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -2,7 +2,7 @@ import { IconButton } from '@chakra-ui/react';
 import CommonIcon from '../Icon';
 
 interface CommonIconButtonProps {
-  type: 'delete' | 'create' | 'up' | 'modify' | 'add' | 'detail' | 'back';
+  type: 'delete' | 'create' | 'up' | 'update' | 'add' | 'detail' | 'back';
   width?: string;
   height?: string;
   fontSize?: string;
@@ -48,7 +48,7 @@ const CommonIconButton = ({ type, width, height, fontSize, onClick }: CommonIcon
         onClick={onClick}
       />
     ),
-    modify: (
+    update: (
       <IconButton
         variant="unstyled"
         aria-label={`${type}`}

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -1,0 +1,86 @@
+import { IconButton } from '@chakra-ui/react';
+import CommonIcon from '../Icon';
+
+interface CommonIconButtonProps {
+  type: 'delete' | 'create' | 'up' | 'modify' | 'add' | 'detail';
+  onClick: () => void;
+}
+
+const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
+  const iconButton = {
+    delete: (
+      <IconButton
+        variant="unstyled"
+        aria-label={`${type}`}
+        w="2.5rem"
+        h="2.5rem"
+        icon={<CommonIcon type="trashcan" />}
+        onClick={onClick}
+      />
+    ),
+    create: (
+      <IconButton
+        isRound
+        color="white"
+        bgColor="blue.300"
+        w="4.0625rem"
+        h="4.0625rem"
+        fontSize="1.4375rem"
+        aria-label={`${type}`}
+        icon={<CommonIcon type="pen" />}
+        onClick={onClick}
+      />
+    ),
+    up: (
+      <IconButton
+        isRound
+        color="white"
+        bgColor="gray.700"
+        w="2.5rem"
+        h="2.5rem"
+        aria-label={`${type}`}
+        icon={<CommonIcon type="arrowUp" />}
+        onClick={onClick}
+      />
+    ),
+    modify: (
+      <IconButton
+        variant="unstyled"
+        aria-label={`${type}`}
+        w="2.5rem"
+        h="2.5rem"
+        icon={<CommonIcon type="pen" />}
+        onClick={onClick}
+      />
+    ),
+    add: (
+      <IconButton
+        isRound
+        color="white"
+        bgColor="blue.300"
+        w="4.0625rem"
+        h="4.0625rem"
+        fontSize="1.4375rem"
+        aria-label={`${type}`}
+        icon={<CommonIcon type="plus" />}
+        onClick={onClick}
+      />
+    ),
+    detail: (
+      <IconButton
+        variant="unstyled"
+        aria-label={`${type}`}
+        fontSize="1.5rem"
+        w="2.5rem"
+        h="2.5rem"
+        display="flex"
+        icon={<CommonIcon type="chevronRight" />}
+        onClick={onClick}
+      />
+    ),
+  };
+
+  return <>{iconButton[type]}</>;
+};
+
+export default CommonIconButton;

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -2,18 +2,22 @@ import { IconButton } from '@chakra-ui/react';
 import CommonIcon from '../Icon';
 
 interface CommonIconButtonProps {
-  type: 'delete' | 'create' | 'up' | 'modify' | 'add' | 'detail';
+  type: 'delete' | 'create' | 'up' | 'modify' | 'add' | 'detail' | 'back';
+  width?: string;
+  height?: string;
+  fontSize?: string;
   onClick: () => void;
 }
 
-const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
+const CommonIconButton = ({ type, width, height, fontSize, onClick }: CommonIconButtonProps) => {
   const iconButton = {
     delete: (
       <IconButton
         variant="unstyled"
         aria-label={`${type}`}
-        w="2.5rem"
-        h="2.5rem"
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1rem'}
         icon={<CommonIcon type="trashcan" />}
         onClick={onClick}
       />
@@ -23,9 +27,9 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
         isRound
         color="white"
         bgColor="blue.300"
-        w="4.0625rem"
-        h="4.0625rem"
-        fontSize="1.4375rem"
+        w={width || '4.0625rem'}
+        h={height || '4.0625rem'}
+        fontSize={fontSize || '1.4375rem'}
         aria-label={`${type}`}
         icon={<CommonIcon type="pen" />}
         onClick={onClick}
@@ -36,8 +40,9 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
         isRound
         color="white"
         bgColor="gray.700"
-        w="2.5rem"
-        h="2.5rem"
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1rem'}
         aria-label={`${type}`}
         icon={<CommonIcon type="arrowUp" />}
         onClick={onClick}
@@ -47,8 +52,9 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
       <IconButton
         variant="unstyled"
         aria-label={`${type}`}
-        w="2.5rem"
-        h="2.5rem"
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1rem'}
         icon={<CommonIcon type="pen" />}
         onClick={onClick}
       />
@@ -58,9 +64,9 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
         isRound
         color="white"
         bgColor="blue.300"
-        w="4.0625rem"
-        h="4.0625rem"
-        fontSize="1.4375rem"
+        w={width || '4.0625rem'}
+        h={height || '4.0625rem'}
+        fontSize={fontSize || '1.4375rem'}
         aria-label={`${type}`}
         icon={<CommonIcon type="plus" />}
         onClick={onClick}
@@ -70,9 +76,9 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
       <IconButton
         variant="unstyled"
         aria-label={`${type}`}
-        fontSize="1.5rem"
-        w="2.5rem"
-        h="2.5rem"
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1.5rem'}
         display="flex"
         icon={<CommonIcon type="chevronRight" />}
         onClick={onClick}

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -78,6 +78,18 @@ const CommonIconButton = ({ type, onClick }: CommonIconButtonProps) => {
         onClick={onClick}
       />
     ),
+    back: (
+      <IconButton
+        variant="unstyled"
+        aria-label={`${type}`}
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1.25rem'}
+        display="flex"
+        icon={<CommonIcon type="chevronLeft" />}
+        onClick={onClick}
+      />
+    ),
   };
 
   return <>{iconButton[type]}</>;

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -3,9 +3,9 @@ import CommonIcon from '../Icon';
 
 interface CommonIconButtonProps {
   type: 'delete' | 'create' | 'up' | 'update' | 'add' | 'detail' | 'back';
-  width?: string;
-  height?: string;
-  fontSize?: string;
+  width?: `${number}rem`;
+  height?: `${number}rem`;
+  fontSize?: `${number}rem`;
   onClick: () => void;
 }
 


### PR DESCRIPTION
## 구현(수정) 내용
CommonIconButton 컴포넌트를 구현했습니다.
컴포넌트의 props타입은 아래와 같습니다.
```typescript
interface CommonIconButtonProps {
  type: 'delete' | 'create' | 'up' | 'update' | 'add' | 'detail' | 'back';
  width?: `${number}rem`;
  height?: `${number}rem`;
  fontSize?: `${number}rem`;
  onClick: () => void;
}
```

사용방법은 아래와 같습니다.
```javascript
<CommonIconButton type="create" onClick={() => {}} />
<CommonIconButton type="add" onClick={() => {}} />
<CommonIconButton type="up" onClick={() => {}} />
<CommonIconButton type="detail" onClick={() => {}} />
<CommonIconButton type="delete" onClick={() => {}} />
<CommonIconButton type="update" onClick={() => {}} />
<CommonIconButton type="back" onClick={() => {}} />
```

## 스크린샷
위의 사용방법의 코드 순서로 타입을 보시면 됩니다.

![스크린샷 2023-11-01 오후 10 31 17](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/faefb7fb-928a-496a-87e1-59bbe33b6067)

## PR 포인트 및 궁금한 점
크기를 디자인에 맞춰서 설정했기때문에 크기를 조정할 수 없는 상태입니다. 추후에 크기 조정이 필요하면 수정하겠습니다.
