### PR TITLE
[OMCT-104] CommonMenu 컴포넌트 구현

### DIFF
--- a/src/components/common/Menu/index.tsx
+++ b/src/components/common/Menu/index.tsx
@@ -4,7 +4,7 @@ import CommonIcon from '../Icon';
 interface CommonMenuProps {
   type: 'update' | 'logout' | 'create';
   onUpdate?: () => void;
-  onDelete?: () => void;
+  onDelete: () => void;
   onLogout?: () => void;
   onCreate?: () => void;
 }
@@ -12,10 +12,6 @@ interface CommonMenuProps {
 const CommonMenu = ({ type, onUpdate, onDelete, onLogout, onCreate }: CommonMenuProps) => {
   const handleUpdate = () => {
     onUpdate && onUpdate();
-  };
-
-  const handleDelete = () => {
-    onDelete && onDelete();
   };
 
   const handleLogout = () => {
@@ -31,21 +27,21 @@ const CommonMenu = ({ type, onUpdate, onDelete, onLogout, onCreate }: CommonMenu
       <>
         <MenuItem onClick={handleUpdate}>수정</MenuItem>
         <MenuDivider m="0" />
-        <MenuItem onClick={handleDelete}>삭제</MenuItem>
+        <MenuItem onClick={onDelete}>삭제</MenuItem>
       </>
     ),
     logout: (
       <>
         <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         <MenuDivider m="0" />
-        <MenuItem onClick={handleDelete}>탈퇴</MenuItem>
+        <MenuItem onClick={onDelete}>탈퇴</MenuItem>
       </>
     ),
     create: (
       <>
         <MenuItem onClick={handleCreate}>생성</MenuItem>
         <MenuDivider m="0" />
-        <MenuItem onClick={handleDelete}>삭제</MenuItem>
+        <MenuItem onClick={onDelete}>삭제</MenuItem>
       </>
     ),
   };

--- a/src/components/common/Menu/index.tsx
+++ b/src/components/common/Menu/index.tsx
@@ -33,27 +33,9 @@ const CommonMenu = ({
   };
 
   const menus = {
-    update: (
-      <>
-        <MenuItem onClick={handleUpdate}>수정</MenuItem>
-        <MenuDivider m="0" />
-        <MenuItem onClick={onDelete}>삭제</MenuItem>
-      </>
-    ),
-    logout: (
-      <>
-        <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
-        <MenuDivider m="0" />
-        <MenuItem onClick={onDelete}>탈퇴</MenuItem>
-      </>
-    ),
-    create: (
-      <>
-        <MenuItem onClick={handleCreate}>생성</MenuItem>
-        <MenuDivider m="0" />
-        <MenuItem onClick={onDelete}>삭제</MenuItem>
-      </>
-    ),
+    update: <MenuItem onClick={handleUpdate}>수정</MenuItem>,
+    logout: <MenuItem onClick={handleLogout}>로그아웃</MenuItem>,
+    create: <MenuItem onClick={handleCreate}>생성</MenuItem>,
   };
 
   return (
@@ -67,6 +49,8 @@ const CommonMenu = ({
       />
       <MenuList p="0" minW="0" w="6rem" fontSize={fontSize}>
         {menus[type]}
+        <MenuDivider m="0" />
+        <MenuItem onClick={onDelete}>{type === 'logout' ? '탈퇴' : '삭제'}</MenuItem>
       </MenuList>
     </Menu>
   );

--- a/src/components/common/Menu/index.tsx
+++ b/src/components/common/Menu/index.tsx
@@ -20,22 +20,14 @@ const CommonMenu = ({
   onLogout,
   onCreate,
 }: CommonMenuProps) => {
-  const handleUpdate = () => {
-    onUpdate && onUpdate();
-  };
-
-  const handleLogout = () => {
-    onLogout && onLogout();
-  };
-
-  const handleCreate = () => {
-    onCreate && onCreate();
+  const handleClick = (onEvent?: () => void) => {
+    onEvent && onEvent();
   };
 
   const menus = {
-    update: <MenuItem onClick={handleUpdate}>수정</MenuItem>,
-    logout: <MenuItem onClick={handleLogout}>로그아웃</MenuItem>,
-    create: <MenuItem onClick={handleCreate}>생성</MenuItem>,
+    update: <MenuItem onClick={() => handleClick(onUpdate)}>수정</MenuItem>,
+    logout: <MenuItem onClick={() => handleClick(onLogout)}>로그아웃</MenuItem>,
+    create: <MenuItem onClick={() => handleClick(onCreate)}>생성</MenuItem>,
   };
 
   return (

--- a/src/components/common/Menu/index.tsx
+++ b/src/components/common/Menu/index.tsx
@@ -3,13 +3,23 @@ import CommonIcon from '../Icon';
 
 interface CommonMenuProps {
   type: 'update' | 'logout' | 'create';
+  iconSize?: `${number}rem`;
+  fontSize?: `${number}rem`;
   onUpdate?: () => void;
   onDelete: () => void;
   onLogout?: () => void;
   onCreate?: () => void;
 }
 
-const CommonMenu = ({ type, onUpdate, onDelete, onLogout, onCreate }: CommonMenuProps) => {
+const CommonMenu = ({
+  type,
+  iconSize = '1.25rem',
+  fontSize = '1rem',
+  onUpdate,
+  onDelete,
+  onLogout,
+  onCreate,
+}: CommonMenuProps) => {
   const handleUpdate = () => {
     onUpdate && onUpdate();
   };
@@ -51,11 +61,11 @@ const CommonMenu = ({ type, onUpdate, onDelete, onLogout, onCreate }: CommonMenu
       <MenuButton
         as={IconButton}
         display="flex"
-        fontSize="1.25rem"
+        fontSize={iconSize}
         icon={<CommonIcon type="ellipsis" />}
         variant="unstyled"
       />
-      <MenuList p="0" minW="0" w="6rem">
+      <MenuList p="0" minW="0" w="6rem" fontSize={fontSize}>
         {menus[type]}
       </MenuList>
     </Menu>

--- a/src/components/common/Menu/index.tsx
+++ b/src/components/common/Menu/index.tsx
@@ -1,0 +1,69 @@
+import { IconButton, Menu, MenuButton, MenuList, MenuItem, MenuDivider } from '@chakra-ui/react';
+import CommonIcon from '../Icon';
+
+interface CommonMenuProps {
+  type: 'update' | 'logout' | 'create';
+  onUpdate?: () => void;
+  onDelete?: () => void;
+  onLogout?: () => void;
+  onCreate?: () => void;
+}
+
+const CommonMenu = ({ type, onUpdate, onDelete, onLogout, onCreate }: CommonMenuProps) => {
+  const handleUpdate = () => {
+    onUpdate && onUpdate();
+  };
+
+  const handleDelete = () => {
+    onDelete && onDelete();
+  };
+
+  const handleLogout = () => {
+    onLogout && onLogout();
+  };
+
+  const handleCreate = () => {
+    onCreate && onCreate();
+  };
+
+  const menus = {
+    update: (
+      <>
+        <MenuItem onClick={handleUpdate}>수정</MenuItem>
+        <MenuDivider m="0" />
+        <MenuItem onClick={handleDelete}>삭제</MenuItem>
+      </>
+    ),
+    logout: (
+      <>
+        <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
+        <MenuDivider m="0" />
+        <MenuItem onClick={handleDelete}>탈퇴</MenuItem>
+      </>
+    ),
+    create: (
+      <>
+        <MenuItem onClick={handleCreate}>생성</MenuItem>
+        <MenuDivider m="0" />
+        <MenuItem onClick={handleDelete}>삭제</MenuItem>
+      </>
+    ),
+  };
+
+  return (
+    <Menu autoSelect={false}>
+      <MenuButton
+        as={IconButton}
+        display="flex"
+        fontSize="1.25rem"
+        icon={<CommonIcon type="ellipsis" />}
+        variant="unstyled"
+      />
+      <MenuList p="0" minW="0" w="6rem">
+        {menus[type]}
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default CommonMenu;


### PR DESCRIPTION
## 구현(수정) 내용
CommonMenu 컴포넌트를 구현했습니다.
타입으로 update, logout, create가 있습니다.
update는 피드, 댓글, 리뷰, 인벤토리에서 쓰이고 
logout은 마이에서 쓰이며
create는 버킷, 아이템에서 쓰입니다.

컴포넌트의 props 타입은 아래와 같습니다.
```typescript
interface CommonMenuProps {
  type: 'update' | 'logout' | 'create';
  iconSize?: `${number}rem`;
  fontSize?: `${number}rem`;
  onUpdate?: () => void;
  onDelete: () => void;
  onLogout?: () => void;
  onCreate?: () => void;
}
```

사용방법은 아래와 같습니다.
```javascript
<CommonMenu type="update" onUpdate={() => {}} onDelete={() => {}} />
<CommonMenu type="logout" onLogout={() => {}} onDelete={() => {}} />
<CommonMenu type="create" onCreate={() => {}} onDelete={() => {}} />
```

## 스크린샷
위 사용방법의 코드 순서로 보시면 됩니다.

![스크린샷 2023-11-01 오후 5 58 16](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/4037e8f5-1ac2-4ea6-b89b-7870093b4e4c)
![스크린샷 2023-11-01 오후 5 58 24](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/7c4c968d-ffdb-4658-b57f-9116347772fe)
![스크린샷 2023-11-01 오후 5 58 38](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/0535a0e8-5931-4322-ac27-87be0bc3c64f)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
