### PR TITLE
[OMCT-102] CommonRadio 컴포넌트 제작

### DIFF
--- a/src/components/common/Radio/RadioCard.tsx
+++ b/src/components/common/Radio/RadioCard.tsx
@@ -1,0 +1,31 @@
+import { Box, useRadio, RadioProps } from '@chakra-ui/react';
+
+const RadioCard = (props: RadioProps) => {
+  const { getInputProps, getRadioProps } = useRadio(props);
+
+  const input = getInputProps();
+  const checkbox = getRadioProps();
+
+  return (
+    <Box as="label">
+      <input {...input} />
+      <Box
+        {...checkbox}
+        cursor="pointer"
+        borderWidth={0.38}
+        borderRadius="0.375rem"
+        _checked={{
+          bg: 'blue.300',
+          color: 'white',
+          borderColor: 'teal.600',
+        }}
+        px={2}
+        py={2}
+      >
+        {props.children}
+      </Box>
+    </Box>
+  );
+};
+
+export default RadioCard;

--- a/src/components/common/Radio/RadioCard.tsx
+++ b/src/components/common/Radio/RadioCard.tsx
@@ -1,4 +1,5 @@
 import { Box, useRadio, RadioProps } from '@chakra-ui/react';
+import CommonText from '../Text';
 
 const RadioCard = (props: RadioProps) => {
   const { getInputProps, getRadioProps } = useRadio(props);
@@ -12,17 +13,18 @@ const RadioCard = (props: RadioProps) => {
       <Box
         {...checkbox}
         cursor="pointer"
-        borderWidth={0.38}
+        borderWidth="0.024rem"
         borderRadius="0.375rem"
         _checked={{
           bg: 'blue.300',
           color: 'white',
           borderColor: 'teal.600',
         }}
-        px={2}
-        py={2}
+        p="0rem 1rem"
       >
-        {props.children}
+        <CommonText type="strongInfo" color={input.checked ? 'white' : 'blue.300'} noOfLines={1}>
+          {String(props.value)}
+        </CommonText>
       </Box>
     </Box>
   );

--- a/src/components/common/Radio/index.tsx
+++ b/src/components/common/Radio/index.tsx
@@ -1,0 +1,44 @@
+import { HStack, useRadioGroup } from '@chakra-ui/react';
+import RadioCard from './RadioCard';
+
+// 관심사(name)
+// value(배열형태로) -> 몇개 들어올지 알수 있다
+// color? -> 이 색으로 유지할꺼면 이 컴포넌트 안에서 그대로 수행
+// isClick -> 선택된게 있는지 확인
+// onClick -> 상태 변경
+// 디바운스 필요
+
+interface CommonRadio {
+  values: string[];
+  name: string;
+  defaultValue: string;
+  onChange: () => void;
+}
+
+const CommonRadio = ({ values, defaultValue, name, onChange }: CommonRadio) => {
+  const options = [...values];
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name,
+    defaultValue,
+    onChange,
+  });
+
+  const group = getRootProps();
+
+  return (
+    <HStack {...group}>
+      {options.map((value) => {
+        const radio = getRadioProps({ value });
+
+        return (
+          <RadioCard key={value} {...radio}>
+            {value}
+          </RadioCard>
+        );
+      })}
+    </HStack>
+  );
+};
+
+export default CommonRadio;

--- a/src/components/common/Radio/index.tsx
+++ b/src/components/common/Radio/index.tsx
@@ -11,7 +11,7 @@ import RadioCard from './RadioCard';
 interface CommonRadio {
   values: string[];
   name: string;
-  defaultValue: string;
+  defaultValue?: string;
   onChange: () => void;
 }
 


### PR DESCRIPTION
## 구현(수정) 내용
CommonRadio 컴포넌트 구현
- 훅을 사용해서 `getRootProps,getRadioProps,getInputProps`를 뺀 이유는 속성을 가져와서 좀 더 쉽게 jsx를 작성하기 위해서 했습니다
- change가 될때마다 re-rendering이 발생해서 디바운스 훅을 따로 제작해서 나중에 다시 pr 올리겠습니다!
- text는 commonText를 사용해서 작성을 해야할것 같습니다!
- props 중 values는 취미 목록(전체)이고 defaultValue는 초기에 선택된 아이템 입니다

```
// 사용방법
import { useState } from 'react';
import CommonRadio from './components/common/Radio/index';

const initalHobby = ['수영', '자전거', '농구'];

const App = () => {
  const [selected, setSelected] = useState<string>(initalHobby[1]);

  return <CommonRadio values={initalHobby} name="취미" onChange={setSelected} />;
};

export default App;

```
## 스크린샷

<img width="838" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/0f189386-3f8f-4204-955f-415cc5c1bae9">

## PR 포인트 및 궁금한 점

