### PR TITLE
[OMCT-118] CommonTag 컴포넌트 구현

### DIFF
--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,0 +1,36 @@
+import { Tag, TagLabel, TagCloseButton } from '@chakra-ui/react';
+import { ReactElement } from 'react';
+import CommonIcon from '../Icon/index';
+
+interface CommonTagProps {
+  type: 'feed' | 'search';
+  children: ReactElement;
+  onClick: () => void;
+  onDelete?: () => void;
+}
+
+const CommonTag = ({ type, children, onClick, onDelete }: CommonTagProps) => {
+  const tag = {
+    feed: (
+      <Tag onClick={() => onClick()} size="md" variant="subtle" color="white" bg="blackAlpha.700">
+        <TagLabel>{children}</TagLabel>
+        <CommonIcon type="chevronRight" />
+      </Tag>
+    ),
+    search: (
+      <Tag onClick={() => onClick()} size="md" variant="subtle" bg="blue.100">
+        <TagLabel>{children}</TagLabel>
+        <TagCloseButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete!();
+          }}
+        />
+      </Tag>
+    ),
+  };
+
+  return <>{tag[type]}</>;
+};
+
+export default CommonTag;

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -5,27 +5,33 @@ import CommonIcon from '../Icon/index';
 interface CommonTagProps {
   type: 'feed' | 'search';
   children: ReactElement;
-  onClick: () => void;
+  onClick?: () => void;
   onDelete?: () => void;
 }
 
 const CommonTag = ({ type, children, onClick, onDelete }: CommonTagProps) => {
-  const handleDelete = (e: MouseEvent) => {
+  const handleClick = (e: MouseEvent, onEvent?: () => void) => {
     e.stopPropagation();
-    onDelete && onDelete();
+    onEvent && onEvent();
   };
 
   const tag = {
     feed: (
-      <Tag onClick={onClick} size="md" variant="subtle" color="white" bg="blackAlpha.700">
+      <Tag
+        onClick={(e) => handleClick(e, onClick)}
+        size="md"
+        variant="subtle"
+        color="white"
+        bg="blackAlpha.700"
+      >
         <TagLabel>{children}</TagLabel>
         <CommonIcon type="chevronRight" />
       </Tag>
     ),
     search: (
-      <Tag onClick={onClick} size="md" variant="subtle" bg="blue.100">
+      <Tag onClick={(e) => handleClick(e, onClick)} size="md" variant="subtle" bg="blue.100">
         <TagLabel>{children}</TagLabel>
-        <TagCloseButton onClick={handleDelete} />
+        <TagCloseButton onClick={(e) => handleClick(e, onDelete)} />
       </Tag>
     ),
   };

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,5 +1,5 @@
 import { Tag, TagLabel, TagCloseButton } from '@chakra-ui/react';
-import { ReactElement } from 'react';
+import { ReactElement, MouseEvent } from 'react';
 import CommonIcon from '../Icon/index';
 
 interface CommonTagProps {
@@ -10,22 +10,22 @@ interface CommonTagProps {
 }
 
 const CommonTag = ({ type, children, onClick, onDelete }: CommonTagProps) => {
+  const handleDelete = (e: MouseEvent) => {
+    e.stopPropagation();
+    onDelete && onDelete();
+  };
+
   const tag = {
     feed: (
-      <Tag onClick={() => onClick()} size="md" variant="subtle" color="white" bg="blackAlpha.700">
+      <Tag onClick={onClick} size="md" variant="subtle" color="white" bg="blackAlpha.700">
         <TagLabel>{children}</TagLabel>
         <CommonIcon type="chevronRight" />
       </Tag>
     ),
     search: (
-      <Tag onClick={() => onClick()} size="md" variant="subtle" bg="blue.100">
+      <Tag onClick={onClick} size="md" variant="subtle" bg="blue.100">
         <TagLabel>{children}</TagLabel>
-        <TagCloseButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete!();
-          }}
-        />
+        <TagCloseButton onClick={handleDelete} />
       </Tag>
     ),
   };


### PR DESCRIPTION
## 구현(수정) 내용
CommonTag 컴포넌트
- 이벤트 버블링 방지하기 위해서 `e.stopPropagation();`를 추가했습니다!
- `type,onClick`만 선언하면 사용하실수 있습니다! `onDelete`는 필요한 구간만 정의해서 사용하시면 됩니다!

## 스크린샷
<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/e284adf6-e859-497e-a728-26687ef3f419">

## PR 포인트 및 궁금한 점
- 확장성있게 짜볼려고 두개이지만 객체로 구현했는데 어떤게 좋을지 궁금합니다!(은근 겹치는 속성들이 많아서 고민입니다ㅠㅠ)
```
// 삼항 연산자로 했을때
import { Tag, TagLabel, TagCloseButton } from '@chakra-ui/react';
import { ReactElement } from 'react';
import CommonIcon from '../Icon/index';

interface CommonTagProps {
  isFeed: boolean;
  children: ReactElement;
  onClick: () => void;
  onDelete?: () => void;
}

const CommonTag = ({ isFeed, children, onClick, onDelete }: CommonTagProps) => {
  return (
    <Tag
      onClick={() => onClick()}
      size="md"
      variant="subtle"
      bg={isFeed ? 'blackAlpha.700' : 'blue.100'}
    >
      <TagLabel>{children}</TagLabel>
      {isFeed ? <CommonIcon type="chevronRight" /> : <TagCloseButton onClick={() => onDelete!()} />}
    </Tag>
  );
};

export default CommonTag;

```