### PR TITLE
[OMCT-117] CommonCard 컴포넌트 구현

### DIFF
--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,0 +1,27 @@
+import { Card, CardHeader, CardBody } from '@chakra-ui/react';
+import { ReactElement } from 'react';
+import CommonBadge from '../Badge';
+
+interface CommonCardProps {
+  count: number;
+  children: ReactElement;
+  onClick: () => void;
+}
+
+const CommonCard = ({ count, children, onClick }: CommonCardProps) => {
+  return (
+    <Card
+      onClick={onClick}
+      maxW="24.5rem"
+      minH="16.1875rem"
+      boxShadow="0px 1px 2px 0px rgba(0, 0, 0, 0.06), 0px 1px 3px 0px rgba(0, 0, 0, 0.10)"
+    >
+      <CardHeader p="0">
+        <CommonBadge type="vote" count={count} />
+      </CardHeader>
+      <CardBody px="1.56rem">{children}</CardBody>
+    </Card>
+  );
+};
+
+export default CommonCard;


### PR DESCRIPTION
## 구현(수정) 내용
CommonCard 컴포넌트 구현
- CardBody에 `px` 과 CardHeader에 `p` 추가했습니다
- Card에 전체적인 ui 속성을 추가했습니다

## 스크린샷
<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/aad15ffe-912e-4153-a808-173e2ccdcbac">

## PR 포인트 및 궁금한 점

- 현재 1곳에만 쓰여서 maxW,minH를 고정시켜서 확장성이 없는데 props로 받으면 확장성이 더 나을것 같은데 다들 생각하시나요??!
- CommonImage 컴포넌트에 이벤트 버블링을 추가하면 좋을것 같습니다!
- CardFooter에 날짜 정보를 넣으면 더 좋을것 같은데 어떻게 생각하시나요??!
