### PR TITLE
[OMCT-106] CommonButton 컴포넌트 구현

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button } from '@chakra-ui/react';
 import CommonIcon from '../Icon';
+import { MouseEvent } from 'react';
 
 interface CommonButtonProps {
   type:
@@ -19,6 +20,11 @@ interface CommonButtonProps {
 }
 
 const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonButtonProps) => {
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    onClick();
+  };
+
   const button = {
     md_full: (
       <Button
@@ -28,7 +34,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="100%"
         px="1rem"
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -42,7 +48,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="18.125rem"
         px="1rem"
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -56,7 +62,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="15rem"
         px="1rem"
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -70,7 +76,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="7.25rem"
         px="1rem"
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -85,7 +91,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         bg={isClick ? 'blue.300' : undefined}
         color={isClick ? 'white' : 'blue.300'}
         leftIcon={<CommonIcon type="heart" />}
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -98,19 +104,19 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="outline"
         border="1px solid var(--white, #FFF);"
         leftIcon={<CommonIcon type="chevronRight" />}
-        onClick={onClick}
+        onClick={handleClick}
         isDisabled={isDisabled}
       >
         {children}
       </Button>
     ),
     text: (
-      <Button colorScheme="blue" onClick={onClick} variant="link" isDisabled={isDisabled}>
+      <Button colorScheme="blue" onClick={handleClick} variant="link" isDisabled={isDisabled}>
         {children}
       </Button>
     ),
     sm_text: (
-      <Button colorScheme="gray" onClick={onClick} variant="link" isDisabled={isDisabled}>
+      <Button colorScheme="gray" onClick={handleClick} variant="link" isDisabled={isDisabled}>
         {children}
       </Button>
     ),
@@ -121,7 +127,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         height="5.625rem"
         borderRadius="0.625rem"
         bg=" linear-gradient(90deg, #E2E8F0 0%, #EDF2F7 100%)"
-        onClick={onClick}
+        onClick={handleClick}
         disabled={isDisabled}
       >
         <CommonIcon type="plus" />

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,0 +1,135 @@
+import { Box, Button } from '@chakra-ui/react';
+import CommonIcon from '../Icon';
+
+interface CommonButtonProps {
+  type:
+    | 'md_full'
+    | 'md_middle'
+    | 'md_base'
+    | 'md_small'
+    | 'sm'
+    | 'xs'
+    | 'text'
+    | 'sm_text'
+    | 'custom';
+  isClick?: boolean;
+  isDisabled: boolean;
+  children: string;
+  onClick: () => void;
+}
+
+const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonButtonProps) => {
+  const button = {
+    md_full: (
+      <Button
+        size="md"
+        bg="blue.300"
+        colorScheme="blue"
+        variant="solid"
+        width="100%"
+        px="1rem"
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    md_middle: (
+      <Button
+        size="md"
+        bg="blue.300"
+        colorScheme="blue"
+        variant="solid"
+        width="18.125rem"
+        px="1rem"
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    md_base: (
+      <Button
+        size="md"
+        bg="blue.300"
+        colorScheme="blue"
+        variant="solid"
+        width="15rem"
+        px="1rem"
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    md_small: (
+      <Button
+        size="md"
+        bg="blue.700"
+        colorScheme="blue"
+        variant="solid"
+        width="7.25rem"
+        px="1rem"
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    sm: (
+      <Button
+        size="sm"
+        colorScheme="blue"
+        variant="outline"
+        border="1px solid var(--blue-300, #63B3ED);"
+        bg={isClick ? 'blue.300' : undefined}
+        color={isClick ? 'white' : 'blue.300'}
+        leftIcon={<CommonIcon type="heart" />}
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    xs: (
+      <Button
+        size="xs"
+        colorScheme="gray"
+        variant="outline"
+        border="1px solid var(--white, #FFF);"
+        leftIcon={<CommonIcon type="chevronRight" />}
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </Button>
+    ),
+    text: (
+      <Button colorScheme="blue" onClick={onClick} variant="link" isDisabled={isDisabled}>
+        {children}
+      </Button>
+    ),
+    sm_text: (
+      <Button colorScheme="gray" onClick={onClick} variant="link" isDisabled={isDisabled}>
+        {children}
+      </Button>
+    ),
+    custom: (
+      <Box
+        as="button"
+        width="6.125rem"
+        height="5.625rem"
+        borderRadius="0.625rem"
+        bg=" linear-gradient(90deg, #E2E8F0 0%, #EDF2F7 100%)"
+        onClick={onClick}
+        disabled={isDisabled}
+      >
+        <CommonIcon type="plus" />
+      </Box>
+    ),
+  };
+
+  return <>{button[type]}</>;
+};
+
+export default CommonButton;

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,9 +1,8 @@
 import { Box, Button } from '@chakra-ui/react';
-import { MouseEvent } from 'react';
 import CommonIcon from '../Icon';
 
 interface CommonButtonProps {
-  type: 'MdFull' | 'MdMiddle' | 'MdBase' | 'MdSmall' | 'sm' | 'xs' | 'text' | 'smText' | 'custom';
+  type: 'mdFull' | 'mdMiddle' | 'mdBase' | 'mdSmall' | 'sm' | 'xs' | 'text' | 'smText' | 'custom';
   isClick?: boolean;
   isDisabled: boolean;
   children: string;
@@ -11,13 +10,8 @@ interface CommonButtonProps {
 }
 
 const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonButtonProps) => {
-  const handleClick = (e: MouseEvent) => {
-    e.stopPropagation();
-    onClick();
-  };
-
   const button = {
-    MdFull: (
+    mdFull: (
       <Button
         size="md"
         bg="blue.300"
@@ -25,13 +19,13 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="100%"
         px="1rem"
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
       </Button>
     ),
-    MdMiddle: (
+    mdMiddle: (
       <Button
         size="md"
         bg="blue.300"
@@ -39,13 +33,13 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="18.125rem"
         px="1rem"
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
       </Button>
     ),
-    MdBase: (
+    mdBase: (
       <Button
         size="md"
         bg="blue.300"
@@ -53,13 +47,13 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="15rem"
         px="1rem"
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
       </Button>
     ),
-    MdSmall: (
+    mdSmall: (
       <Button
         size="md"
         bg="blue.700"
@@ -67,7 +61,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         variant="solid"
         width="7.25rem"
         px="1rem"
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -78,11 +72,11 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         size="sm"
         colorScheme="blue"
         variant="outline"
-        border="1px solid var(--blue-300, #63B3ED);"
+        borderColor="blue.300"
         bg={isClick ? 'blue.300' : undefined}
         color={isClick ? 'white' : 'blue.300'}
         leftIcon={<CommonIcon type="heart" />}
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
@@ -93,21 +87,21 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         size="xs"
         colorScheme="gray"
         variant="outline"
-        border="1px solid var(--white, #FFF);"
+        borderColor="white"
         leftIcon={<CommonIcon type="chevronRight" />}
-        onClick={handleClick}
+        onClick={onClick}
         isDisabled={isDisabled}
       >
         {children}
       </Button>
     ),
     text: (
-      <Button colorScheme="blue" onClick={handleClick} variant="link" isDisabled={isDisabled}>
+      <Button colorScheme="blue" onClick={onClick} variant="link" isDisabled={isDisabled}>
         {children}
       </Button>
     ),
-    SmText: (
-      <Button colorScheme="gray" onClick={handleClick} variant="link" isDisabled={isDisabled}>
+    smText: (
+      <Button colorScheme="gray" onClick={onClick} variant="link" isDisabled={isDisabled}>
         {children}
       </Button>
     ),
@@ -118,7 +112,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         height="5.625rem"
         borderRadius="0.625rem"
         bg=" linear-gradient(90deg, #E2E8F0 0%, #EDF2F7 100%)"
-        onClick={handleClick}
+        onClick={onClick}
         disabled={isDisabled}
       >
         <CommonIcon type="plus" />

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,18 +1,9 @@
 import { Box, Button } from '@chakra-ui/react';
-import CommonIcon from '../Icon';
 import { MouseEvent } from 'react';
+import CommonIcon from '../Icon';
 
 interface CommonButtonProps {
-  type:
-    | 'md_full'
-    | 'md_middle'
-    | 'md_base'
-    | 'md_small'
-    | 'sm'
-    | 'xs'
-    | 'text'
-    | 'sm_text'
-    | 'custom';
+  type: 'MdFull' | 'MdMiddle' | 'MdBase' | 'MdSmall' | 'sm' | 'xs' | 'text' | 'smText' | 'custom';
   isClick?: boolean;
   isDisabled: boolean;
   children: string;
@@ -26,7 +17,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
   };
 
   const button = {
-    md_full: (
+    MdFull: (
       <Button
         size="md"
         bg="blue.300"
@@ -40,7 +31,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         {children}
       </Button>
     ),
-    md_middle: (
+    MdMiddle: (
       <Button
         size="md"
         bg="blue.300"
@@ -54,7 +45,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         {children}
       </Button>
     ),
-    md_base: (
+    MdBase: (
       <Button
         size="md"
         bg="blue.300"
@@ -68,7 +59,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         {children}
       </Button>
     ),
-    md_small: (
+    MdSmall: (
       <Button
         size="md"
         bg="blue.700"
@@ -115,7 +106,7 @@ const CommonButton = ({ type, isDisabled, isClick, children, onClick }: CommonBu
         {children}
       </Button>
     ),
-    sm_text: (
+    SmText: (
       <Button colorScheme="gray" onClick={handleClick} variant="link" isDisabled={isDisabled}>
         {children}
       </Button>


### PR DESCRIPTION
## 구현(수정) 내용
CommonButton 컴포넌트
- `isDisabled`은 모든 버튼에 해당될것 같아서 다 할당 했습니다!
- `isClick`은 좋아요 버튼에 한정이 될것 같아서 좋아요 버튼에만 할당했습니다
- size 별로 이름을 구분했습니다
- `type[full]`은 이 버튼을 감싸는 전체 layout width가 어떻게 설정하느냐에 따라서 전체적으로 할당되도록 설정하였습니다


## 스크린샷
<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/8c460362-6c60-4e2c-bbe6-e99c04e6a27a">

<img width="913" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/05d692f9-bd29-42c1-8a58-d93a1cb819c8">

## PR 포인트 및 궁금한 점
- 짜고보니깐 공통된 부분이 많아서 이렇게 하는지 많은지 의문이 들었습니다ㅠㅠ
