### PR TITLE
[OMCT-69] CommonToast 컴포넌트 구현

### DIFF
--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -11,9 +11,9 @@ const CommonToast = ({ message, type }: OpenToastProps) => {
         alignItems="center"
         justifyContent="center"
         color="blue.900"
-        p={3}
+        p="0.69rem"
         bg="blue.100"
-        gap={2}
+        gap="0.5rem"
       >
         {type === 'success' ? (
           <CommonIcon type="circleCheck" size="1.5rem" color="green.400" />

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,0 +1,35 @@
+import { Flex } from '@chakra-ui/react';
+import CommonIcon from '../Icon';
+import { OpenToastProps } from '../../../hooks/useCustomToast';
+import CommonText from '../Text';
+
+const CommonToast = ({ message, type }: OpenToastProps) => {
+  return (
+    <>
+      <Flex
+        borderRadius="0.625rem"
+        alignItems="center"
+        justifyContent="center"
+        color="blue.900"
+        p={3}
+        bg="blue.100"
+        gap={2}
+      >
+        {type === 'success' ? (
+          <CommonIcon type="circleCheck" size="1.5rem" color="green.400" />
+        ) : (
+          <CommonIcon
+            type="circleExclamation"
+            size="1.5rem"
+            color={type === 'error' ? 'red.400' : 'blue.800'}
+          />
+        )}
+        <CommonText type="normalInfo" color="blue.900" noOfLines={0}>
+          {message}
+        </CommonText>
+      </Flex>
+    </>
+  );
+};
+
+export default CommonToast;

--- a/src/hooks/useCustomToast.tsx
+++ b/src/hooks/useCustomToast.tsx
@@ -19,9 +19,7 @@ const useCustomToast = () => {
     });
   };
 
-  return {
-    openToast,
-  };
+  return openToast;
 };
 
 export default useCustomToast;

--- a/src/hooks/useCustomToast.tsx
+++ b/src/hooks/useCustomToast.tsx
@@ -1,0 +1,27 @@
+import { useToast } from '@chakra-ui/react';
+import CommonToast from '../components/common/Toast';
+
+export interface OpenToastProps {
+  message: string;
+  type: 'info' | 'success' | 'error';
+}
+
+const TOAST_DURATION = 2000;
+
+const useCustomToast = () => {
+  const toast = useToast();
+
+  const openToast = ({ message, type }: OpenToastProps) => {
+    return toast({
+      position: 'top',
+      duration: TOAST_DURATION,
+      render: () => <CommonToast message={message} type={type} />,
+    });
+  };
+
+  return {
+    openToast,
+  };
+};
+
+export default useCustomToast;


### PR DESCRIPTION
## 구현(수정) 내용
임시방편으로 CommonToast 컴포넌트를 구현했습니다.
toast 훅을 따로 만들었습니다. 🥲
## 스크린샷
https://github.com/bucket-back/bucket-back-frontend/assets/104294861/a73afb03-813d-440d-a203-d379851f96d2

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
