### PR TITLE
[OMCT-112] CommonSkeleton 컴포넌트 구현

### DIFF
--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -11,16 +11,15 @@ import {
 } from '@chakra-ui/react';
 
 interface CommonSkeletonProps {
-  type: 'feed' | 'item' | 'bucket' | 'inProgressVote' | 'endVote';
-  isLoaded?: boolean;
+  type: 'feed' | 'item' | 'bucket' | 'inProgressVote' | 'vote';
 }
 
-const CommonSkeleton = ({ type, isLoaded = false }: CommonSkeletonProps) => {
+const CommonSkeleton = ({ type }: CommonSkeletonProps) => {
   const skeletons = {
     feed: (
       <Stack>
         <Flex>
-          <SkeletonCircle size="2.5rem" isLoaded={isLoaded} />
+          <SkeletonCircle size="2.5rem" />
           <SkeletonText
             mt="0.4rem"
             ml="0.8rem"
@@ -28,7 +27,6 @@ const CommonSkeleton = ({ type, isLoaded = false }: CommonSkeletonProps) => {
             spacing="1"
             skeletonHeight="0.8rem"
             w="6rem"
-            isLoaded={isLoaded}
           />
         </Flex>
         <SkeletonText
@@ -38,63 +36,56 @@ const CommonSkeleton = ({ type, isLoaded = false }: CommonSkeletonProps) => {
           spacing="1"
           skeletonHeight="0.8rem"
           w="15rem"
-          isLoaded={isLoaded}
         />
         <SimpleGrid columns={3} spacing="0.25rem" w="19rem">
           {Array.from({ length: 6 }).map((_, idx) => (
-            <Skeleton
-              key={idx}
-              w="6.125rem"
-              h="5.625rem"
-              borderRadius="0.625rem"
-              isLoaded={isLoaded}
-            />
+            <Skeleton key={idx} w="6.125rem" h="5.625rem" borderRadius="0.625rem" />
           ))}
         </SimpleGrid>
       </Stack>
     ),
     item: (
       <Box>
-        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" />
         <Stack mt="0.3rem" ml="0.5rem" spacing="0.3rem">
-          <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
-          <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+          <Skeleton w="2.5rem" h="0.8rem" />
+          <Skeleton w="4.5rem" h="0.8rem" />
         </Stack>
       </Box>
     ),
     bucket: (
       <Box>
-        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" />
         <VStack mt="0.3rem" spacing="0.3rem">
-          <Skeleton w="2rem" h="0.8rem" isLoaded={isLoaded} />
-          <Skeleton w="3rem" h="0.8rem" isLoaded={isLoaded} />
+          <Skeleton w="2rem" h="0.8rem" />
+          <Skeleton w="3rem" h="0.8rem" />
         </VStack>
       </Box>
     ),
     inProgressVote: (
       <Box>
-        <SkeletonCircle size="5.625rem" isLoaded={isLoaded} />
+        <SkeletonCircle size="5.625rem" />
         <Center mt="0.3rem">
-          <Skeleton w="3rem" h="0.8rem" isLoaded={isLoaded} />
+          <Skeleton w="3rem" h="0.8rem" />
         </Center>
       </Box>
     ),
-    endVote: (
+    vote: (
       <Stack>
-        <Skeleton w="18rem" h="0.8rem" isLoaded={isLoaded} />
+        <Skeleton w="18rem" h="0.8rem" />
         <Flex gap="3.31rem">
           <Stack>
-            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" />
             <Stack ml="0.5rem" spacing="0.3rem">
-              <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
-              <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+              <Skeleton w="2.5rem" h="0.8rem" />
+              <Skeleton w="4.5rem" h="0.8rem" />
             </Stack>
           </Stack>
           <Stack>
-            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" />
             <Stack ml="0.5rem" spacing="0.3rem">
-              <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
-              <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+              <Skeleton w="2.5rem" h="0.8rem" />
+              <Skeleton w="4.5rem" h="0.8rem" />
             </Stack>
           </Stack>
         </Flex>

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,108 @@
+import {
+  Box,
+  Flex,
+  Stack,
+  VStack,
+  Skeleton,
+  SkeletonCircle,
+  SkeletonText,
+  Center,
+  SimpleGrid,
+} from '@chakra-ui/react';
+
+interface CommonSkeletonProps {
+  type: 'feed' | 'item' | 'bucket' | 'inProgressVote' | 'endVote';
+  isLoaded?: boolean;
+}
+
+const CommonSkeleton = ({ type, isLoaded = false }: CommonSkeletonProps) => {
+  const skeletons = {
+    feed: (
+      <Stack>
+        <Flex>
+          <SkeletonCircle size="2.5rem" isLoaded={isLoaded} />
+          <SkeletonText
+            mt="0.4rem"
+            ml="0.8rem"
+            noOfLines={2}
+            spacing="1"
+            skeletonHeight="0.8rem"
+            w="6rem"
+            isLoaded={isLoaded}
+          />
+        </Flex>
+        <SkeletonText
+          mt="0.4rem"
+          ml="0.8rem"
+          noOfLines={2}
+          spacing="1"
+          skeletonHeight="0.8rem"
+          w="15rem"
+          isLoaded={isLoaded}
+        />
+        <SimpleGrid columns={3} spacing="0.25rem" w="19rem">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <Skeleton
+              key={idx}
+              w="6.125rem"
+              h="5.625rem"
+              borderRadius="0.625rem"
+              isLoaded={isLoaded}
+            />
+          ))}
+        </SimpleGrid>
+      </Stack>
+    ),
+    item: (
+      <Box>
+        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+        <Stack mt="0.3rem" ml="0.5rem" spacing="0.3rem">
+          <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
+          <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+        </Stack>
+      </Box>
+    ),
+    bucket: (
+      <Box>
+        <Skeleton w="6.125rem" h="5.625rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+        <VStack mt="0.3rem" spacing="0.3rem">
+          <Skeleton w="2rem" h="0.8rem" isLoaded={isLoaded} />
+          <Skeleton w="3rem" h="0.8rem" isLoaded={isLoaded} />
+        </VStack>
+      </Box>
+    ),
+    inProgressVote: (
+      <Box>
+        <SkeletonCircle size="5.625rem" isLoaded={isLoaded} />
+        <Center mt="0.3rem">
+          <Skeleton w="3rem" h="0.8rem" isLoaded={isLoaded} />
+        </Center>
+      </Box>
+    ),
+    endVote: (
+      <Stack>
+        <Skeleton w="18rem" h="0.8rem" isLoaded={isLoaded} />
+        <Flex gap="3.31rem">
+          <Stack>
+            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+            <Stack ml="0.5rem" spacing="0.3rem">
+              <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
+              <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+            </Stack>
+          </Stack>
+          <Stack>
+            <Skeleton w="9.0625rem" h="6.5rem" borderRadius="0.625rem" isLoaded={isLoaded} />
+            <Stack ml="0.5rem" spacing="0.3rem">
+              <Skeleton w="2.5rem" h="0.8rem" isLoaded={isLoaded} />
+              <Skeleton w="4.5rem" h="0.8rem" isLoaded={isLoaded} />
+            </Stack>
+          </Stack>
+        </Flex>
+      </Stack>
+    ),
+  };
+
+  return <>{skeletons[type]}</>;
+};
+
+export default CommonSkeleton;


### PR DESCRIPTION
## 구현(수정) 내용
CommonSkeleton 컴포넌트를 구현했습니다.
타입으로, feed, item, bucket, inProgressVote, vote가 있습니다.
feed는 말그대로 피드에 쓰이고
item과 bucket 또한 단어 그대로를 의미합니다.
inProgressVote는 진행중인 투표에서 쓰이고
vote는 종료된 투표에 쓰입니다.

컴포넌트의 props 타입은 아래와 같습니다.
```typescript
interface CommonSkeletonProps {
  type: 'feed' | 'item' | 'bucket' | 'inProgressVote' | 'vote';
}
```

사용방법은 아래와 같습니다.
```javascript
<CommonSkeleton type="feed" />
<CommonSkeleton type="item" />
<CommonSkeleton type="bucket" />
<CommonSkeleton type="inProgressVote" />
<CommonSkeleton type="vote" />
```

## 스크린샷
왼쪽부터 feed, item, bucket, inProgressVote, endVote 순입니다.
![스크린샷 2023-11-04 오후 4 30 16](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/4c37497f-e644-46e5-bd04-47bf8cdbb35e)

## PR 포인트 및 궁금한 점
<del>`isLoaded` prop은 표시될지 안될지를 나타낼때 사용되지만 저희 프로젝트에서는 미사용 가능성이 있습니다만 일단 추가했습니다.</del>
