### PR TITLE
[OMCT-163] 경로 별칭 오류 수정

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: [
+      {
+        find: '@',
+        replacement: path.resolve(__dirname, 'src'),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## 구현(수정) 내용
경로 별칭 오류를 수정했습니다.
`vite.config.ts`에 경로 별칭에 대한 설정을 했어야 했는데 까먹고 설정을 안해줘서 오류가 발생했습니다.

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
