### PR TITLE
[OMCT-160] CommonCard 컴포넌트 타입 수정 및 Footer 추가/CommonTag 컴포넌트 타입 수정

### DIFF
--- a/src/shared/components/Card/index.tsx
+++ b/src/shared/components/Card/index.tsx
@@ -1,14 +1,15 @@
-import { ReactElement } from 'react';
-import { Card, CardHeader, CardBody } from '@chakra-ui/react';
-import { CommonBadge } from '@/shared/components';
+import { ReactNode } from 'react';
+import { Card, CardHeader, CardBody, CardFooter } from '@chakra-ui/react';
+import { CommonBadge, DateText } from '@/shared/components';
 
 interface CommonCardProps {
   count: number;
-  children: ReactElement;
+  date: string;
+  children: ReactNode;
   onClick: () => void;
 }
 
-const CommonCard = ({ count, children, onClick }: CommonCardProps) => {
+const CommonCard = ({ count, date, children, onClick }: CommonCardProps) => {
   return (
     <Card
       onClick={onClick}
@@ -20,6 +21,9 @@ const CommonCard = ({ count, children, onClick }: CommonCardProps) => {
         <CommonBadge type="vote" count={count} />
       </CardHeader>
       <CardBody px="1.56rem">{children}</CardBody>
+      <CardFooter justify="end">
+        <DateText createdDate={date} />
+      </CardFooter>
     </Card>
   );
 };

--- a/src/shared/components/Tag/index.tsx
+++ b/src/shared/components/Tag/index.tsx
@@ -1,10 +1,10 @@
-import { ReactElement, MouseEvent } from 'react';
+import { ReactNode, MouseEvent } from 'react';
 import { Tag, TagLabel, TagCloseButton } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
 interface CommonTagProps {
   type: 'feed' | 'search';
-  children: ReactElement;
+  children: ReactNode;
   onClick?: () => void;
   onDelete?: () => void;
 }


### PR DESCRIPTION
## 구현(수정) 내용
CommonCard 타입 수정
- `children: ReactNode;`으로 수정했습니다.
-  CardFooter에 DateText 추가했습니다.

CommonTag 타입 수정
- `children: ReactNode;`으로 수정했습니다.
## 스크린샷

<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/469ef263-04be-4307-93c0-1cebf4371d64">

## PR 포인트 및 궁금한 점

