### PR TITLE
[OMCT-161] CommonDividerImage 컴포넌트 구현

### DIFF
--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from 'react';
+import { Grid, GridItem, Image } from '@chakra-ui/react';
+
+interface CommonDividerImageProps {
+  item: string[];
+  count: number;
+  type: 'base' | 'live';
+}
+
+const BORDERTYPE = 'solid black';
+const ISFIRSTANDTHIRD = (index: number) => index === 1 || index === 3;
+const ISFIRSTANDSECOND = (index: number) => index === 0 || index === 1;
+
+const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
+  const isLastImage = useCallback((index: number) => count - 1 === index, [count]);
+  const isSecondAndThird = useMemo(() => count === 2 || count === 3, [count]);
+
+  const dividerImage = {
+    live: (
+      <Grid
+        templateColumns="repeat(2,1fr)"
+        borderRadius="50%"
+        width="5.625rem"
+        height="5.625rem"
+        overflow="hidden"
+        borderWidth="3px"
+        borderColor="blue.300"
+      >
+        {item.map((image, index) => {
+          return (
+            <GridItem
+              key={index}
+              borderLeft={isLastImage(index) ? '1px solid black' : undefined}
+              width="100%"
+              height="100%"
+            >
+              <Image src={image} width="100%" height="100%" />
+            </GridItem>
+          );
+        })}
+      </Grid>
+    ),
+    base: (
+      <Grid
+        templateColumns={count >= 2 ? 'repeat(2,1fr)' : '1fr'}
+        templateRows={count >= 3 ? 'repeat(2,1fr)' : undefined}
+        width="7rem"
+        height="6.4375rem"
+        borderRadius="0.625rem"
+        background="linear-gradient(90deg, #DCE1E8 0%, #EDF2F7 100%);"
+        overflow="hidden"
+      >
+        {item.map((image, index) => {
+          return (
+            <GridItem
+              key={index}
+              width="100%"
+              height="100%"
+              rowSpan={count === 3 && index === 0 ? 2 : undefined}
+              borderWidth="1px"
+              borderLeft={count === 4 && ISFIRSTANDTHIRD(index) ? BORDERTYPE : undefined}
+              borderRight={isSecondAndThird && index === 0 ? BORDERTYPE : undefined}
+              borderBottom={
+                count > 2 && index === 1
+                  ? BORDERTYPE
+                  : count === 4 && ISFIRSTANDSECOND(index)
+                  ? BORDERTYPE
+                  : undefined
+              }
+            >
+              <Image src={image} width="100%" height="100%" />
+            </GridItem>
+          );
+        })}
+      </Grid>
+    ),
+  };
+
+  return <>{dividerImage[type]}</>;
+};
+
+export default CommonDividerImage;

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -76,7 +76,7 @@ const DividerImage = ({ images, type }: DividerImageProps) => {
     ),
   };
 
-  return <>{count <= 4 && dividerImage[type]}</>;
+  return <>{Boolean(count <= 4) && dividerImage[type]}</>;
 };
 
 export default DividerImage;

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -6,7 +6,7 @@ interface DividerImageProps {
 }
 
 const BORDER_TYPE = '1px solid black';
-const GRID_REPEAT = 'repeat(2,1fr)';
+const GRID_REPEAT = 'repeat(2,minmax(3rem,1fr))';
 
 const isFirstAndThird = (index: number) => index === 1 || index === 3;
 const isFirstAndSecond = (index: number) => index === 0 || index === 1;
@@ -76,7 +76,7 @@ const DividerImage = ({ images, type }: DividerImageProps) => {
     ),
   };
 
-  return <>{dividerImage[type]}</>;
+  return <>{count <= 4 && dividerImage[type]}</>;
 };
 
 export default DividerImage;

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -30,7 +30,8 @@ const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
           return (
             <GridItem
               key={index}
-              borderLeft={isLastImage(index) ? '1px solid black' : undefined}
+              borderWidth="1px"
+              borderLeft={isLastImage(index) ? BORDERTYPE : undefined}
               width="100%"
               height="100%"
             >

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -1,19 +1,20 @@
-import { useCallback, useMemo } from 'react';
 import { Grid, GridItem, Image } from '@chakra-ui/react';
 
-interface CommonDividerImageProps {
-  item: string[];
-  count: number;
+interface DividerImageProps {
+  images: string[];
   type: 'base' | 'live';
 }
 
-const BORDERTYPE = 'solid black';
-const ISFIRSTANDTHIRD = (index: number) => index === 1 || index === 3;
-const ISFIRSTANDSECOND = (index: number) => index === 0 || index === 1;
+const BORDER_TYPE = '1px solid black';
+const GRID_REPEAT = 'repeat(2,1fr)';
 
-const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
-  const isLastImage = useCallback((index: number) => count - 1 === index, [count]);
-  const isSecondAndThird = useMemo(() => count === 2 || count === 3, [count]);
+const isFirstAndThird = (index: number) => index === 1 || index === 3;
+const isFirstAndSecond = (index: number) => index === 0 || index === 1;
+const isLastImage = (index: number, count: number) => count - 1 === index;
+const isSecondAndThird = (count: number) => count === 2 || count === 3;
+
+const DividerImage = ({ images, type }: DividerImageProps) => {
+  const count = images.length;
 
   const dividerImage = {
     live: (
@@ -26,16 +27,15 @@ const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
         borderWidth="3px"
         borderColor="blue.300"
       >
-        {item.map((image, index) => {
+        {images.map((image, index) => {
           return (
             <GridItem
               key={index}
-              borderWidth="1px"
-              borderLeft={isLastImage(index) ? BORDERTYPE : undefined}
+              borderLeft={isLastImage(index, count) ? BORDER_TYPE : undefined}
               width="100%"
               height="100%"
             >
-              <Image src={image} width="100%" height="100%" />
+              <Image src={image} width="100%" height="100%" objectFit="cover" />
             </GridItem>
           );
         })}
@@ -43,33 +43,32 @@ const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
     ),
     base: (
       <Grid
-        templateColumns={count >= 2 ? 'repeat(2,1fr)' : '1fr'}
-        templateRows={count >= 3 ? 'repeat(2,1fr)' : undefined}
+        templateColumns={count >= 2 ? GRID_REPEAT : '1fr'}
+        templateRows={count >= 3 ? GRID_REPEAT : undefined}
         width="7rem"
         height="6.4375rem"
         borderRadius="0.625rem"
         background="linear-gradient(90deg, #DCE1E8 0%, #EDF2F7 100%);"
         overflow="hidden"
       >
-        {item.map((image, index) => {
+        {images.map((image, index) => {
           return (
             <GridItem
               key={index}
               width="100%"
               height="100%"
               rowSpan={count === 3 && index === 0 ? 2 : undefined}
-              borderWidth="1px"
-              borderLeft={count === 4 && ISFIRSTANDTHIRD(index) ? BORDERTYPE : undefined}
-              borderRight={isSecondAndThird && index === 0 ? BORDERTYPE : undefined}
+              borderLeft={count === 4 && isFirstAndThird(index) ? BORDER_TYPE : undefined}
+              borderRight={isSecondAndThird(count) && index === 0 ? BORDER_TYPE : undefined}
               borderBottom={
                 count > 2 && index === 1
-                  ? BORDERTYPE
-                  : count === 4 && ISFIRSTANDSECOND(index)
-                  ? BORDERTYPE
+                  ? BORDER_TYPE
+                  : count === 4 && isFirstAndSecond(index)
+                  ? BORDER_TYPE
                   : undefined
               }
             >
-              <Image src={image} width="100%" height="100%" />
+              <Image src={image} width="100%" height="100%" objectFit="cover" />
             </GridItem>
           );
         })}
@@ -80,4 +79,4 @@ const CommonDividerImage = ({ item, count, type }: CommonDividerImageProps) => {
   return <>{dividerImage[type]}</>;
 };
 
-export default CommonDividerImage;
+export default DividerImage;

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -22,4 +22,4 @@ export { default as CommonTag } from './Tag';
 export { default as CommonText } from './Text';
 export { default as CommonTextarea } from './Textarea';
 export { default as CommonToast } from './Toast';
-export { default as CommonDividerImage } from './DividerImage';
+export { default as DividerImage } from './DividerImage';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -22,3 +22,4 @@ export { default as CommonTag } from './Tag';
 export { default as CommonText } from './Text';
 export { default as CommonTextarea } from './Textarea';
 export { default as CommonToast } from './Toast';
+export { default as CommonDividerImage } from './DividerImage';


### PR DESCRIPTION
## 구현(수정) 내용
CommonDividerImage 컴포넌트 구현
- 예외상황이 많아서 알아보기 쉽게 최대한 상수로 빼서 처리했습니다.
- `useCallback,useMemo` 이용해서 리렌더링을 최소화할려고 했습니다.

## 스크린샷

<img width="1440" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/03faad6e-a3bb-4d23-982b-49502542da6c">

## PR 포인트 및 궁금한 점
