### PR TITLE
[OMCT-179] CommonImage 컴포넌트 작은 이미지 반응형 수정

### DIFF
--- a/src/shared/components/Image/index.tsx
+++ b/src/shared/components/Image/index.tsx
@@ -5,19 +5,18 @@ interface CommonImageProps {
   src?: ImageProps['src'];
   alt?: ImageProps['alt'];
   onClick?: () => void;
-  ratio?: string;
 }
 
 const IMAGE_SIZE = {
-  xs: { borderRadius: 'full', maxWidth: '3.1875rem', maxHeight: '3.1875rem' },
-  sm: { maxWidth: '7rem', maxHeight: '6.4375rem', borderRadius: '0.625rem' },
-  base: { borderRadius: '0.625rem', maxWidth: '9.0625rem', maxHeight: '6.5rem' },
-  md: { borderRadius: '0.625rem', maxWidth: '22.6875rem', maxHeight: '11.6875rem' },
-  lg: { borderRadius: '0.625rem', maxWidth: '21.875rem', maxHeight: '15.6875rem' },
-  xl: { borderRadius: '0.625rem', maxWidth: '20.1875rem', maxHeight: '16.5rem' },
+  xs: { width: '3.1875rem', aspectRatio: '1/1' },
+  sm: { width: '7rem', aspectRatio: '112/103' },
+  base: { width: '9.0625rem', aspectRatio: '145/104' },
+  md: { width: '22.6875rem', aspectRatio: '363/187' },
+  lg: { width: '21.875rem', aspectRatio: '350/251' },
+  xl: { width: '20.1875rem', aspectRatio: '323/264' },
 };
 
-const CommonImage = ({ size, alt, src, onClick, ratio }: CommonImageProps) => {
+const CommonImage = ({ size, alt, src, onClick }: CommonImageProps) => {
   const handleClick = () => {
     onClick && onClick();
   };
@@ -27,13 +26,12 @@ const CommonImage = ({ size, alt, src, onClick, ratio }: CommonImageProps) => {
       src={src}
       alt={alt}
       {...IMAGE_SIZE[size]}
+      maxW="100%"
       objectFit="cover"
-      width="100%"
-      height="auto"
-      aspectRatio={ratio}
+      cursor="pointer"
+      borderRadius={size === 'xs' ? 'full' : '0.625rem'}
       fallbackSrc="https://placehold.co/800?text=Bucket+Back&font=roboto"
       onClick={handleClick}
-      cursor="pointer"
     />
   );
 };


### PR DESCRIPTION
## 구현(수정) 내용
이전의 반응형은 maxW보다 작은 이미지를 넣었을때 가득차지않는 문제점이 있었어요.🥲
maxW를 삭제하고 width를 기본으로 주되 maxW를 100%로 수정한뒤 작은이미지도 채워질수있도록 수정했어요!
height는 aspectRatio로 대체하여 비율에 맞게 이미지가 줄어들수있도록 했어요!
## 스크린샷
모달에서도 잘 적용되는 모습이예요!

https://github.com/bucket-back/bucket-back-frontend/assets/104294861/12a0d9a7-1392-4f11-b59a-ea5eb8dec5d4



## PR 포인트 및 궁금한 점
반응형이 굉장히 말썽이네요ㅠㅅㅠ자주 수정해서 죄송합니다!🥲 