### PR TITLE
[OMCT-186] footer컴포넌트/icon컴포넌트/iconbutton컴포넌트 수정

### DIFF
--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -1,5 +1,7 @@
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Flex } from '@chakra-ui/react';
 import { CommonIcon, CommonText } from '@/shared/components';
+import { COMMON } from '@/shared/styles/Common';
 
 const FOOTER_INFO = [
   {
@@ -11,40 +13,84 @@ const FOOTER_INFO = [
     TEXT: '검색',
   },
   {
-    ICON: 'basket',
+    ICON: 'bucket',
     TEXT: '버킷생성',
   },
   {
-    ICON: 'bag',
+    ICON: 'item',
     TEXT: '아이템목록',
   },
   {
-    ICON: 'my',
+    ICON: 'user',
     TEXT: 'MY',
   },
 ];
-type FooterIcon = 'home' | 'search' | 'basket' | 'bag' | 'my';
+
+type FooterIcon = 'home' | 'search' | 'bucket' | 'item' | 'user';
+
+const isSamePath = (pathname: string, type: string) => pathname.slice(1) === type;
 
 const Footer = () => {
-  const handleClick = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const handleClick = (type: string) => {
+    if (isSamePath(location.pathname, type)) {
+      return;
+    }
     // 추후 페이지 이동 + 아이콘 클릭하면 페이지 상단으로 올라갈수있도록 로직 추가
+    switch (type) {
+      case 'home': {
+        navigate('/');
+        break;
+      }
+      case 'search': {
+        navigate('/search');
+        break;
+      }
+      case 'bucket': {
+        navigate('/bucket/create');
+        break;
+      }
+      case 'bag': {
+        navigate('/item');
+        break;
+      }
+      case 'my': {
+        // navigate(`/user/${:userId}`);
+        break;
+      }
+    }
   };
 
   return (
     <Flex
       height="5rem"
-      bg="red.200"
+      bg={COMMON.COLORS.LIGHT_GRAY}
       alignItems="center"
       justifyContent="space-evenly"
       pos="fixed"
       bottom="0"
-      w="full"
+      maxW="26.875rem"
+      w="100%"
       zIndex={999}
     >
       {FOOTER_INFO.map(({ ICON, TEXT }) => (
-        <Flex key={ICON} flexDirection="column" alignItems="center" onClick={handleClick}>
-          <CommonIcon type={ICON as FooterIcon} size="2rem" color="blue.900" />
-          <CommonText type="smallInfo" color="blue.900" noOfLines={0}>
+        <Flex
+          key={ICON}
+          flexDirection="column"
+          alignItems="center"
+          onClick={() => handleClick(ICON)}
+        >
+          <CommonIcon
+            type={ICON as FooterIcon}
+            size="1.5rem"
+            color={isSamePath(location.pathname, ICON) ? 'blue.300' : 'blue.900'}
+          />
+          <CommonText
+            type="smallInfo"
+            color={isSamePath(location.pathname, ICON) ? 'blue.300' : 'blue.900'}
+            noOfLines={0}
+          >
             {TEXT}
           </CommonText>
         </Flex>

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -1,6 +1,8 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Flex } from '@chakra-ui/react';
 import { CommonIcon, CommonText } from '@/shared/components';
+import useSamePath from '@/shared/hooks/useSamePath';
 import { COMMON } from '@/shared/styles/Common';
 
 const FOOTER_INFO = [
@@ -26,15 +28,17 @@ const FOOTER_INFO = [
   },
 ];
 
+interface FooterProps {
+  children: ReactNode;
+}
+
 type FooterIcon = 'home' | 'search' | 'bucket' | 'item' | 'user';
 
-const isSamePath = (pathname: string, type: string) => pathname.slice(1) === type;
-
-const Footer = () => {
+const Footer = ({ children }: FooterProps) => {
   const navigate = useNavigate();
-  const location = useLocation();
+  const isSamePath = useSamePath();
   const handleClick = (type: string) => {
-    if (isSamePath(location.pathname, type)) {
+    if (isSamePath(type)) {
       return;
     }
     // 추후 페이지 이동 + 아이콘 클릭하면 페이지 상단으로 올라갈수있도록 로직 추가
@@ -51,11 +55,11 @@ const Footer = () => {
         navigate('/bucket/create');
         break;
       }
-      case 'bag': {
+      case 'item': {
         navigate('/item');
         break;
       }
-      case 'my': {
+      case 'user': {
         // navigate(`/user/${:userId}`);
         break;
       }
@@ -68,12 +72,10 @@ const Footer = () => {
       bg={COMMON.COLORS.LIGHT_GRAY}
       alignItems="center"
       justifyContent="space-evenly"
-      pos="fixed"
-      bottom="0"
-      maxW="26.875rem"
       w="100%"
       zIndex={999}
     >
+      {children}
       {FOOTER_INFO.map(({ ICON, TEXT }) => (
         <Flex
           key={ICON}
@@ -84,11 +86,11 @@ const Footer = () => {
           <CommonIcon
             type={ICON as FooterIcon}
             size="1.5rem"
-            color={isSamePath(location.pathname, ICON) ? 'blue.300' : 'blue.900'}
+            color={isSamePath(ICON) ? 'blue.300' : 'blue.900'}
           />
           <CommonText
             type="smallInfo"
-            color={isSamePath(location.pathname, ICON) ? 'blue.300' : 'blue.900'}
+            color={isSamePath(ICON) ? 'blue.300' : 'blue.900'}
             noOfLines={0}
           >
             {TEXT}

--- a/src/shared/components/Icon/index.tsx
+++ b/src/shared/components/Icon/index.tsx
@@ -41,9 +41,9 @@ const ICONS = {
   pen: FaPen,
   cube: FaCube,
   cubes: FaCubes,
-  basket: FaBasketShopping,
-  bag: FaBagShopping,
-  my: FaRegFaceGrin,
+  bucket: FaBasketShopping,
+  item: FaBagShopping,
+  user: FaRegFaceGrin,
   eye: FaEye,
   eyeSlash: FaEyeSlash,
   arrowUp: FaArrowUp,
@@ -70,4 +70,5 @@ interface CommonIconProps {
 const CommonIcon = ({ type, size, color }: CommonIconProps) => {
   return <Icon as={ICONS[type]} boxSize={size} color={color} height="100%" />;
 };
+
 export default CommonIcon;

--- a/src/shared/components/Icon/index.tsx
+++ b/src/shared/components/Icon/index.tsx
@@ -68,7 +68,6 @@ interface CommonIconProps {
 }
 
 const CommonIcon = ({ type, size, color }: CommonIconProps) => {
-  return <Icon as={ICONS[type]} boxSize={size} color={color} />;
+  return <Icon as={ICONS[type]} boxSize={size} color={color} height="100%" />;
 };
-
 export default CommonIcon;

--- a/src/shared/components/IconButton/index.tsx
+++ b/src/shared/components/IconButton/index.tsx
@@ -2,7 +2,7 @@ import { IconButton } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
 interface CommonIconButtonProps {
-  type: 'delete' | 'create' | 'up' | 'update' | 'add' | 'detail' | 'back';
+  type: 'delete' | 'create' | 'up' | 'update' | 'add' | 'detail' | 'back' | 'cancel';
   width?: `${number}rem`;
   height?: `${number}rem`;
   fontSize?: `${number}rem`;
@@ -93,6 +93,18 @@ const CommonIconButton = ({ type, width, height, fontSize, onClick }: CommonIcon
         fontSize={fontSize || '1.25rem'}
         display="flex"
         icon={<CommonIcon type="chevronLeft" />}
+        onClick={onClick}
+      />
+    ),
+    cancel: (
+      <IconButton
+        variant="unstyled"
+        aria-label={`${type}`}
+        w={width || '2.5rem'}
+        h={height || '2.5rem'}
+        fontSize={fontSize || '1.25rem'}
+        display="flex"
+        icon={<CommonIcon type="circleXmark" />}
         onClick={onClick}
       />
     ),

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useCustomToast } from './useCustomToast';
+export { default as useSamePath } from './useSamePath';

--- a/src/shared/hooks/useSamePath.tsx
+++ b/src/shared/hooks/useSamePath.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router-dom';
+
+const useSamePath = () => {
+  const location = useLocation();
+  const isSamePath = (path: string) => {
+    // bucket생성 -> 버킷생성일때
+    if (location.pathname.slice(1).split('/')[0] === path) {
+      return true;
+    }
+    if (
+      path === 'home' &&
+      (!location.pathname.slice(1).length ||
+        location.pathname.slice(1) === 'vote' ||
+        location.pathname.slice(1) === 'feed')
+    ) {
+      return true;
+    }
+
+    return location.pathname.slice(1) === path;
+  };
+
+  return isSamePath;
+};
+
+export default useSamePath;


### PR DESCRIPTION
## 구현(수정) 내용
footer 컴포넌트
- path에 맞게 type 수정 및 icon 이름 수정
- 클릭시 이동가능하도록 기능 추가
- 클릭된 경우 어떤위치인지 표시기능 추가

icon 컴포넌트
- icon 이름 수정(path에 맞게)
- height 꽉차게 해서 가운데 맞게 디자인 수정

iconButton 컴포넌트
- cancel iconButton 추가

## 스크린샷
iconButton 컴포넌트
<img width="308" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/af373691-1793-4179-8b89-975349454c03">
footer컴포넌트
<img width="307" alt="image" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/17cd0a67-1a89-43b0-a777-0079835b152b">

## PR 포인트 및 궁금한 점
