### PR TITLE
[OMCT-188] 투표 페이지 ui 구현

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -3,6 +3,7 @@ import App from '@/App';
 import { FeedCreate } from '@/pages';
 import VoteCreate from '@/pages/Vote/VoteCreate';
 import VoteDetail from '@/pages/Vote/VoteDetail';
+import VoteHome from '@/pages/Vote/VoteHome';
 
 export const router = createBrowserRouter([
   {
@@ -31,7 +32,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'vote',
-        element: <div>vote</div>,
+        element: <VoteHome />,
       },
       {
         path: 'vote/create',

--- a/src/features/vote/components/VoteInProgress/index.tsx
+++ b/src/features/vote/components/VoteInProgress/index.tsx
@@ -1,0 +1,30 @@
+import { Flex } from '@chakra-ui/react';
+import { CommonText, DividerImage } from '@/shared/components';
+
+const TEMP_IMAGE = 'https://placehold.co/800?text=Bucket+Back&font=roboto';
+
+const VoteInProgress = () => {
+  return (
+    <Flex flexDir="column" gap="1rem">
+      <CommonText type="normalInfo">진행중인 투표</CommonText>
+      <Flex overflowX="auto" gap="0.7rem">
+        {Array.from({ length: 10 }, (_, index) => {
+          return (
+            <Flex
+              key={index}
+              flexDir="column"
+              gap="0.5rem"
+              alignItems="center"
+              marginBottom="1.5rem"
+            >
+              <DividerImage type="live" images={[TEMP_IMAGE, TEMP_IMAGE]} />
+              <CommonText type="smallInfo">00명 참여중!</CommonText>
+            </Flex>
+          );
+        })}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default VoteInProgress;

--- a/src/features/vote/components/VoteInProgress/index.tsx
+++ b/src/features/vote/components/VoteInProgress/index.tsx
@@ -1,30 +1,53 @@
-import { Flex } from '@chakra-ui/react';
+import styled from '@emotion/styled';
 import { CommonText, DividerImage } from '@/shared/components';
 
 const TEMP_IMAGE = 'https://placehold.co/800?text=Bucket+Back&font=roboto';
 
 const VoteInProgress = () => {
   return (
-    <Flex flexDir="column" gap="1rem">
-      <CommonText type="normalInfo">진행중인 투표</CommonText>
-      <Flex overflowX="auto" gap="0.7rem">
+    <Container>
+      <TitleWrapper>
+        <CommonText type="normalInfo">진행중인 투표</CommonText>
+      </TitleWrapper>
+      <ContentsWrapper>
         {Array.from({ length: 10 }, (_, index) => {
           return (
-            <Flex
-              key={index}
-              flexDir="column"
-              gap="0.5rem"
-              alignItems="center"
-              marginBottom="1.5rem"
-            >
+            <ContentsBox key={index}>
               <DividerImage type="live" images={[TEMP_IMAGE, TEMP_IMAGE]} />
               <CommonText type="smallInfo">00명 참여중!</CommonText>
-            </Flex>
+            </ContentsBox>
           );
         })}
-      </Flex>
-    </Flex>
+      </ContentsWrapper>
+    </Container>
   );
 };
 
 export default VoteInProgress;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const TitleWrapper = styled.div`
+  padding-top: 1rem;
+  padding-left: 1.25rem;
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  gap: 0.7rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-bottom: 1rem;
+  overflow-x: scroll;
+`;
+
+const ContentsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+`;

--- a/src/features/vote/components/VoteItem/index.tsx
+++ b/src/features/vote/components/VoteItem/index.tsx
@@ -1,0 +1,27 @@
+import { Box, Flex } from '@chakra-ui/react';
+import { CommonCard, CommonImage, CommonText } from '@/shared/components';
+
+const VoteItem = () => {
+  return (
+    <CommonCard count={0} date="2023-11-12T12:16:49.407Z" onClick={() => {}}>
+      <Flex flexDir="column" gap="1rem">
+        <CommonText type="smallInfo">이거 엄마한테 선물드릴려고하는데 어떰?</CommonText>
+        <Flex alignItems="center" gap="0.5rem">
+          <Box>
+            <CommonImage size="base" />
+            <CommonText type="smallInfo">29,800</CommonText>
+            <CommonText type="smallInfo">아이템 이름입니다.</CommonText>
+          </Box>
+          <CommonText type="smallInfo">VS</CommonText>
+          <Box>
+            <CommonImage size="base" />
+            <CommonText type="smallInfo">29,800</CommonText>
+            <CommonText type="smallInfo">아이템 이름입니다.</CommonText>
+          </Box>
+        </Flex>
+      </Flex>
+    </CommonCard>
+  );
+};
+
+export default VoteItem;

--- a/src/features/vote/components/VoteItem/index.tsx
+++ b/src/features/vote/components/VoteItem/index.tsx
@@ -1,27 +1,49 @@
-import { Box, Flex } from '@chakra-ui/react';
+import styled from '@emotion/styled';
 import { CommonCard, CommonImage, CommonText } from '@/shared/components';
 
 const VoteItem = () => {
   return (
     <CommonCard count={0} date="2023-11-12T12:16:49.407Z" onClick={() => {}}>
-      <Flex flexDir="column" gap="1rem">
+      <ContentsContainer>
         <CommonText type="smallInfo">이거 엄마한테 선물드릴려고하는데 어떰?</CommonText>
-        <Flex alignItems="center" gap="0.5rem">
-          <Box>
+        <ContentsWrapper>
+          <ContentsBox>
             <CommonImage size="base" />
             <CommonText type="smallInfo">29,800</CommonText>
             <CommonText type="smallInfo">아이템 이름입니다.</CommonText>
-          </Box>
-          <CommonText type="smallInfo">VS</CommonText>
-          <Box>
+          </ContentsBox>
+          <VsBox>
+            <CommonText type="smallInfo" noOfLines={0}>
+              VS
+            </CommonText>
+          </VsBox>
+          <ContentsBox>
             <CommonImage size="base" />
             <CommonText type="smallInfo">29,800</CommonText>
             <CommonText type="smallInfo">아이템 이름입니다.</CommonText>
-          </Box>
-        </Flex>
-      </Flex>
+          </ContentsBox>
+        </ContentsWrapper>
+      </ContentsContainer>
     </CommonCard>
   );
 };
 
 export default VoteItem;
+
+const ContentsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const ContentsBox = styled.div``;
+
+const VsBox = styled.div`
+  flex-shrink: 0;
+`;

--- a/src/features/vote/components/Votes/index.tsx
+++ b/src/features/vote/components/Votes/index.tsx
@@ -1,21 +1,21 @@
-import { Flex } from '@chakra-ui/react';
+import styled from '@emotion/styled';
 import { CommonTabs } from '@/shared/components';
 import VoteItem from '../VoteItem';
 
 const Votes = () => {
   return (
-    <>
+    <Container>
       <CommonTabs
         tabsData={[
           {
             label: '종료된 투표',
             content: (
-              <Flex flexDir="column" alignItems="center" gap="2rem" overflowY="scroll">
+              <ContentsWrapper>
                 <VoteItem />
                 <VoteItem />
                 <VoteItem />
                 <VoteItem />
-              </Flex>
+              </ContentsWrapper>
             ),
           },
           {
@@ -28,8 +28,24 @@ const Votes = () => {
           },
         ]}
       />
-    </>
+    </Container>
   );
 };
 
 export default Votes;
+
+const Container = styled.div`
+  background-color: white;
+  padding-top: 2rem;
+  border-radius: 2rem 2rem 0 0;
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  overflow-y: scroll;
+  height: calc(100vh - 20rem);
+  padding: 1rem 0;
+`;

--- a/src/features/vote/components/Votes/index.tsx
+++ b/src/features/vote/components/Votes/index.tsx
@@ -1,0 +1,35 @@
+import { Flex } from '@chakra-ui/react';
+import { CommonTabs } from '@/shared/components';
+import VoteItem from '../VoteItem';
+
+const Votes = () => {
+  return (
+    <>
+      <CommonTabs
+        tabsData={[
+          {
+            label: '종료된 투표',
+            content: (
+              <Flex flexDir="column" alignItems="center" gap="2rem" overflowY="scroll">
+                <VoteItem />
+                <VoteItem />
+                <VoteItem />
+                <VoteItem />
+              </Flex>
+            ),
+          },
+          {
+            label: '올린 투표',
+            content: '',
+          },
+          {
+            label: '참여한 투표',
+            content: '',
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export default Votes;

--- a/src/main.css
+++ b/src/main.css
@@ -11,3 +11,25 @@
   font-weight: normal;
   font-style: normal;
 }
+
+::-webkit-scrollbar {
+  width: 14px;
+  height: 14px;
+}
+
+::-webkit-scrollbar-thumb {
+  outline: none;
+  border-radius: 10px;
+  border: 4px solid transparent;
+  box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.15);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  border: 4px solid transparent;
+  box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.3);
+}
+
+::-webkit-scrollbar-track {
+  box-shadow: none;
+  background-color: transparent;
+}

--- a/src/pages/Vote/VoteHome/index.tsx
+++ b/src/pages/Vote/VoteHome/index.tsx
@@ -1,11 +1,11 @@
-import { Box } from '@chakra-ui/react';
+import styled from '@emotion/styled';
 import { CommonTabs } from '@/shared/components';
 import VoteInProgress from '@/features/vote/components/VoteInProgress';
 import Votes from '@/features/vote/components/Votes';
 
 const VoteHome = () => {
   return (
-    <Box>
+    <Container>
       <CommonTabs
         tabsType="soft-rounded"
         isFitted={false}
@@ -13,10 +13,10 @@ const VoteHome = () => {
           {
             label: '자전거',
             content: (
-              <Box gap="5rem">
+              <>
                 <VoteInProgress />
                 <Votes />
-              </Box>
+              </>
             ),
           },
           {
@@ -29,8 +29,12 @@ const VoteHome = () => {
           },
         ]}
       />
-    </Box>
+    </Container>
   );
 };
 
 export default VoteHome;
+
+const Container = styled.div`
+  background-color: #f7fafc;
+`;

--- a/src/pages/Vote/VoteHome/index.tsx
+++ b/src/pages/Vote/VoteHome/index.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@chakra-ui/react';
+import { CommonTabs } from '@/shared/components';
+import VoteInProgress from '@/features/vote/components/VoteInProgress';
+import Votes from '@/features/vote/components/Votes';
+
+const VoteHome = () => {
+  return (
+    <Box>
+      <CommonTabs
+        tabsType="soft-rounded"
+        isFitted={false}
+        tabsData={[
+          {
+            label: '자전거',
+            content: (
+              <Box gap="5rem">
+                <VoteInProgress />
+                <Votes />
+              </Box>
+            ),
+          },
+          {
+            label: '수영',
+            content: '',
+          },
+          {
+            label: '농구',
+            content: '',
+          },
+        ]}
+      />
+    </Box>
+  );
+};
+
+export default VoteHome;

--- a/src/shared/components/Card/index.tsx
+++ b/src/shared/components/Card/index.tsx
@@ -20,8 +20,8 @@ const CommonCard = ({ count, date, children, onClick }: CommonCardProps) => {
       <CardHeader p="0">
         <CommonBadge type="vote" count={count} />
       </CardHeader>
-      <CardBody px="1.56rem">{children}</CardBody>
-      <CardFooter justify="end">
+      <CardBody paddingBottom="0">{children}</CardBody>
+      <CardFooter padding="0 1rem 0.75rem 0" justify="end">
         <DateText createdDate={date} />
       </CardFooter>
     </Card>

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -21,7 +21,7 @@ const DividerImage = ({ images, type }: DividerImageProps) => {
       <Grid
         templateColumns={GRID_REPEAT}
         borderRadius="50%"
-        width="100%"
+        width="5.625rem"
         aspectRatio="1/1"
         overflow="hidden"
         borderWidth="3px"

--- a/src/shared/components/Tabs/index.tsx
+++ b/src/shared/components/Tabs/index.tsx
@@ -19,7 +19,7 @@ const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line', onClick }: C
 
   return (
     <Tabs isFitted={isFitted} variant={tabsType} size="sm">
-      <TabList>
+      <TabList padding={tabsType === 'soft-rounded' ? '1rem 0 0 1rem' : undefined}>
         {tabsData.map((tab, index) => (
           <Tab
             onClick={handleClick}
@@ -38,7 +38,7 @@ const CommonTabs = ({ tabsData, isFitted = true, tabsType = 'line', onClick }: C
       </TabList>
       <TabPanels>
         {tabsData.map((tab, index) => (
-          <TabPanel p={4} key={index}>
+          <TabPanel padding="0" key={index}>
             {tab.content}
           </TabPanel>
         ))}


### PR DESCRIPTION
## 구현(수정) 내용
투표 페이지 ui 구현했습니다.

## 스크린샷
![스크린샷 2023-11-13 오후 5 22 57](https://github.com/bucket-back/bucket-back-frontend/assets/104294861/f380cdf8-d50d-4bae-bfbe-191add8288f3)

## PR 포인트 및 궁금한 점
레이아웃을 잡다보니 문제사항이 생겨서 도와주셨으면 합니다! 스크롤이 문제군요...🔥
### 1.  종료된 투표안에 세로스크롤 추가
`<TabPanel p={0} key={index} display="flex" flexDir="column" maxH="60vh">` => 60vh는 임의로 둔것
종료된 투표안에만 세로 스크롤을 추가하기 위해서는 탭컴포넌트의 TabPanel에 height를 지정해줘야 스크롤이 생깁니다.
높이 지정을 안해줬을 경우 넘처 흐릅니다🥲[[관련링크]]( https://github.com/chakra-ui/chakra-ui/issues/361)
![image](https://github.com/bucket-back/bucket-back-frontend/assets/104294861/001446fa-f8cb-4f36-9964-eeb00bd2aaa9)
또한 높이를 지정해준다해도 반응형을 고려하기에는 어렵습니다ㅠㅠ
너무 작은 화면일때에도 여전히 넘처흐르는 문제점이 있습니다.(se기준)
야매인 방법인것같아서 더 좋은 해결책이 필요해보입니다! 

### 2.  진행중인 투표안의 Divider Image 반응형
찬욱님이 수정해주신  Divider Image를 반영하면 overflowx가 먹지를 않습니다..🥲
overflowx를 사용하기위해서는 고정된 width가 필요해보입니다.ㅠㅠ
help....me...................................😇

수정사항이 있다면 언제든지 알려주세요! 감사합니다!
