### PR TITLE
[OMCT-183] FeedDetail 페이지 구현, CommoInput 컴포넌트 수정, CommonButton 컴포넌트 수정, Header 컴포넌트 수정

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from '@/App';
-import { FeedCreate } from '@/pages';
+import { FeedCreate, FeedDetail } from '@/pages';
 import VoteCreate from '@/pages/Vote/VoteCreate';
 import VoteDetail from '@/pages/Vote/VoteDetail';
 
@@ -23,7 +23,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'feed/:feedId',
-        element: <div>feed feedId</div>,
+        element: <FeedDetail />,
       },
       {
         path: 'feed/:feedId/edit',

--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -2,7 +2,6 @@ import { createBrowserRouter } from 'react-router-dom';
 import App from '@/App';
 import { FeedCreate, FeedDetail } from '@/pages';
 import ItemList from '@/pages/Item/List';
-import { FeedCreate } from '@/pages';
 import VoteCreate from '@/pages/Vote/VoteCreate';
 import VoteDetail from '@/pages/Vote/VoteDetail';
 import VoteHome from '@/pages/Vote/VoteHome';

--- a/src/features/feed/components/FeedComment/index.tsx
+++ b/src/features/feed/components/FeedComment/index.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import {
+  CommonButton,
+  CommonIcon,
+  CommonMenu,
+  CommonText,
+  DateText,
+  Profile,
+} from '@/shared/components';
+
+const FeedComment = () => {
+  return (
+    <Container>
+      <ProfileWrapper>
+        <Profile nickName="테스트" levelNumber={10} isAdopted />
+        <CommonMenu type="update" iconSize="0.25rem" onDelete={() => {}} onUpdate={() => {}} />
+      </ProfileWrapper>
+      <ContentsWrapper>
+        <CommonText type="smallInfo">테스트</CommonText>
+      </ContentsWrapper>
+      <ContentsWrapper>
+        <DateText createdDate="2021-10-15T20:48:19.816Z" />
+        <InteractPanel>
+          <CommonIcon type="heart" size="0.75rem" />
+          <CommonText type="smallInfo">0</CommonText>
+          <CommonButton type="xsText">좋아요</CommonButton>
+          <CommonButton type="xsText">인벤토리</CommonButton>
+          <CommonButton type="xsText">채택하기</CommonButton>
+        </InteractPanel>
+      </ContentsWrapper>
+    </Container>
+  );
+};
+
+export default FeedComment;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.75rem;
+`;
+
+const ProfileWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  padding: 0.25rem 0.5rem;
+`;
+
+const InteractPanel = styled.div`
+  display: flex;
+  gap: 0.2rem;
+  padding-left: 0.2rem;
+`;

--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -5,6 +5,8 @@ import {
   Profile,
   DateText,
   CommonImage,
+  CommonMenu,
+  CommonButton,
 } from '@/shared/components';
 import {
   Container,
@@ -18,6 +20,7 @@ import {
   LikeNumber,
   CommentBox,
   CommentNumber,
+  BucketInfoBox,
 } from './style';
 
 interface Member {
@@ -42,7 +45,10 @@ interface FeedItemProps {
   commentCount: number;
   createAt: string;
   feedItems: Item[];
+  isDetail: boolean;
   onClick: (id: number) => void;
+  onUpdate: (id: number) => void;
+  onDelete: (id: number) => void;
 }
 
 const FeedItem = ({
@@ -90,8 +96,11 @@ const FeedItem = ({
       itemUrl: 'https://www.naver.com/',
     },
   ],
+  isDetail = false,
   onClick,
-}: FeedItemProps) => {
+  onUpdate,
+  onDelete,
+}: Partial<FeedItemProps>) => {
   return (
     <Container>
       <ProfileWrapper>
@@ -101,32 +110,54 @@ const FeedItem = ({
           levelNumber={memberInfo.level}
           isAdopted={false}
         />
+        {isDetail && (
+          <CommonMenu
+            type="update"
+            iconSize="0.35rem"
+            onUpdate={() => onUpdate && onUpdate(feedId)}
+            onDelete={() => onDelete && onDelete(feedId)}
+          />
+        )}
       </ProfileWrapper>
-      <ContentsWrapper onClick={() => onClick(feedId)}>
-        <CommonText type="smallInfo" color="inherit" noOfLines={3}>
+      <ContentsWrapper onClick={() => onClick && onClick(feedId)}>
+        <CommonText type="smallInfo" color="inherit" noOfLines={isDetail ? 10 : 3}>
           {feedContent}
         </CommonText>
+        {isDetail && (
+          <BucketInfoBox>
+            <CommonText type="normalInfo">하얀 개구리 조합</CommonText>
+            <CommonText type="normalInfo">29,000원</CommonText>
+          </BucketInfoBox>
+        )}
         <ImageBox>
           {feedItems.map((item) => (
             <CommonImage key={item.itemId} size="sm" src={item.itemImage} />
           ))}
-          <BucketTitleTag>
-            <CommonTag type="feed">
-              <CommonText type="smallInfo">하얀 개구리 조합</CommonText>
-            </CommonTag>
-          </BucketTitleTag>
+          {!isDetail && (
+            <BucketTitleTag>
+              <CommonTag type="feed">
+                <CommonText type="smallInfo">하얀 개구리 조합</CommonText>
+              </CommonTag>
+            </BucketTitleTag>
+          )}
         </ImageBox>
         <DetailInfoWrapper>
           <DateText createdDate={createAt} />
           <InteractPanel>
-            <LikeBox>
-              <CommonIcon type={isLike ? 'fillHeart' : 'heart'} />
-              <LikeNumber>{likeCount}</LikeNumber>
-            </LikeBox>
-            <CommentBox>
-              <CommonIcon type="comment" />
-              <CommentNumber>{commentCount}</CommentNumber>
-            </CommentBox>
+            {isDetail ? (
+              <CommonButton type="sm">3</CommonButton>
+            ) : (
+              <>
+                <LikeBox>
+                  <CommonIcon type={isLike ? 'fillHeart' : 'heart'} />
+                  <LikeNumber>{likeCount}</LikeNumber>
+                </LikeBox>
+                <CommentBox>
+                  <CommonIcon type="comment" />
+                  <CommentNumber>{commentCount}</CommentNumber>
+                </CommentBox>
+              </>
+            )}
           </InteractPanel>
         </DetailInfoWrapper>
       </ContentsWrapper>

--- a/src/features/feed/components/FeedItem/style.tsx
+++ b/src/features/feed/components/FeedItem/style.tsx
@@ -9,6 +9,8 @@ export const Container = styled.div`
 `;
 
 export const ProfileWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
   padding: 0 1.5rem;
 `;
 
@@ -17,6 +19,10 @@ export const ContentsWrapper = styled.div`
   flex-direction: column;
   gap: 0.3rem;
   padding: 0 2.5rem;
+`;
+
+export const BucketInfoBox = styled.div`
+  margin-top: 1rem;
 `;
 
 export const ImageBox = styled.div`

--- a/src/features/feed/components/index.ts
+++ b/src/features/feed/components/index.ts
@@ -1,2 +1,3 @@
 export { default as FeedItem } from './FeedItem';
 export { default as FeedSelectBucket } from './FeedSelectBucket';
+export { default as FeedComment } from './FeedComment';

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+import { CommonButton, CommonDivider, CommonInput, CommonText, Header } from '@/shared/components';
+import { FeedComment, FeedItem } from '@/features/feed/components';
+
+const FeedDetail = () => {
+  return (
+    <>
+      <Header type="back" />
+
+      <FeedDetailContainer>
+        <FeedDetailWrapper>
+          <FeedItem isDetail />
+        </FeedDetailWrapper>
+      </FeedDetailContainer>
+      <div>
+        <CommonDivider size="lg" />
+        <CommentNumberWrapper>
+          <CommonText type="normalInfo">총 0개의 댓글</CommonText>
+        </CommentNumberWrapper>
+        <CommonDivider size="sm" />
+      </div>
+
+      <CommentsContainer>
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+        <FeedComment />
+        <CommonDivider size="sm" />
+      </CommentsContainer>
+      <CommentInputContainer>
+        <CommonInput
+          size="md"
+          type="text"
+          width="100%"
+          placeholder="댓글을 입력해주세요"
+          rightIcon={<CommonButton type="mdFull">등록</CommonButton>}
+        />
+      </CommentInputContainer>
+    </>
+  );
+};
+
+export default FeedDetail;
+
+const FeedDetailContainer = styled.div`
+  /* display: flex;
+  flex-direction: column; */
+`;
+
+const FeedDetailWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 0.5rem;
+`;
+
+const CommentsContainer = styled.div`
+  height: 100%;
+  overflow-y: scroll;
+`;
+
+const CommentNumberWrapper = styled.div`
+  padding: 1rem 1.75rem;
+`;
+
+const CommentInputContainer = styled.div`
+  padding: 0 0.5rem 0.5rem 0.5rem;
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as FeedCreate } from './Feed/FeedCreate';
+export { default as FeedDetail } from './Feed/FeedDetail';

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -2,7 +2,17 @@ import { Box, Button } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
 interface CommonButtonProps {
-  type: 'mdFull' | 'mdMiddle' | 'mdBase' | 'mdSmall' | 'sm' | 'xs' | 'text' | 'smText' | 'custom';
+  type:
+    | 'mdFull'
+    | 'mdMiddle'
+    | 'mdBase'
+    | 'mdSmall'
+    | 'sm'
+    | 'xs'
+    | 'text'
+    | 'smText'
+    | 'xsText'
+    | 'custom';
   isClick?: boolean;
   isDisabled?: boolean;
   children?: string;
@@ -131,6 +141,21 @@ const CommonButton = ({
     ),
     smText: (
       <Button
+        colorScheme="gray"
+        onClick={handleClick}
+        variant="link"
+        isDisabled={isDisabled}
+        _hover={{
+          textDecor: 'none',
+        }}
+        type={isSubmit ? 'submit' : 'button'}
+      >
+        {children}
+      </Button>
+    ),
+    xsText: (
+      <Button
+        size="xs"
         colorScheme="gray"
         onClick={handleClick}
         variant="link"

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -19,7 +19,7 @@ const Header = ({ type }: HeaderProps) => {
   };
 
   return (
-    <Box height="5rem" pl="1.75rem" width="full" as="header">
+    <Box height="5rem" pl="1.75rem" width="full" flexShrink={0} as="header">
       <Flex h="full" alignItems="center">
         {headerType[type]}
       </Flex>

--- a/src/shared/components/Input/index.tsx
+++ b/src/shared/components/Input/index.tsx
@@ -19,7 +19,7 @@ interface CommonInputProps {
   leftIcon?: ReactElement;
   rightIcon?: ReactElement;
   size?: 'sm' | 'md' | 'lg';
-  width?: `${number}rem`;
+  width?: string;
 }
 
 const CommonInput = forwardRef(


### PR DESCRIPTION
## 구현(수정) 내용
FeedDetail 페이지를 구현했습니다.
UI 우선으로 구현하여 기능은 추후에 추가하겠습니다.
style 파일로 아직 분리하지 않았습니다.

CommonInput 컴포넌트의 width prop 타입에 100%를 인자로 넘겨주기위해 string으로 타입을 수정했습니다.

CommonButton 컴포넌트에 xsText 타입의 버튼을 추가했습니다.

Header 컴포넌트의 높이가 줄어드는 현상이 있어서 flexShrink 속성을 추가했습니다.
## 스크린샷
![스크린샷 2023-11-13 오후 10 29 50](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/3567a9ef-d9d4-4eaf-85de-6e39cb4434d3)

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
