### PR TITLE
[OMCT-218] MemberHome 페이지 구현

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -1,8 +1,8 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from '@/App';
-import { FeedCreate, FeedDetail, FeedHome, Home } from '@/pages';
-import ItemList from '@/pages/Item/List';
+import { FeedCreate, FeedDetail, FeedHome, Home, MemberHome } from '@/pages';
 import ItemCreate from '@/pages/Item/Create';
+import ItemList from '@/pages/Item/List';
 import VoteCreate from '@/pages/Vote/VoteCreate';
 import VoteDetail from '@/pages/Vote/VoteDetail';
 import VoteHome from '@/pages/Vote/VoteHome';
@@ -79,44 +79,44 @@ export const router = createBrowserRouter([
         element: <div>review reviewId edit</div>,
       },
       {
-        path: 'user/edit',
-        element: <div>user edit</div>,
+        path: 'member/edit',
+        element: <div>member edit</div>,
       },
       {
-        path: 'user/edit/password',
-        element: <div>user edit password</div>,
+        path: 'member/edit/password',
+        element: <div>member edit password</div>,
       },
       {
-        path: 'user/:userId',
-        element: <div>user userId</div>,
+        path: 'member/:memberId',
+        element: <MemberHome />,
       },
       {
-        path: 'user/:userId/inventory',
-        element: <div>user userId inventory</div>,
+        path: 'member/:memberId/inventory',
+        element: <div>member memberId inventory</div>,
       },
       {
-        path: 'user/:userId/inventory/:inventoryId',
-        element: <div>user userId inventory inventoryId</div>,
+        path: 'member/:memberId/inventory/:inventoryId',
+        element: <div>member memberId inventory inventoryId</div>,
       },
       {
         path: 'inventory/create',
         element: <div>inventory create</div>,
       },
       {
-        path: 'user/:userId/bucket',
-        element: <div>user userId bucket</div>,
+        path: 'member/:memberId/bucket',
+        element: <div>member memberId bucket</div>,
       },
       {
-        path: 'user/:userId/bucket/:bucketId',
-        element: <div>user userId bucket bucketId</div>,
+        path: 'member/:memberId/bucket/:bucketId',
+        element: <div>member memberId bucket bucketId</div>,
       },
       {
         path: 'bucket/create',
         element: <div>bucket create</div>,
       },
       {
-        path: 'user/:userId/feed',
-        element: <div>user userId feed</div>,
+        path: 'member/:memberId/feed',
+        element: <div>member memberId feed</div>,
       },
       {
         path: 'login',

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -1,0 +1,9 @@
+import { useParams } from 'react-router-dom';
+
+const MemberHome = () => {
+  const { memberId } = useParams();
+
+  return <>{memberId}</>;
+};
+
+export default MemberHome;

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -1,9 +1,111 @@
 import { useParams } from 'react-router-dom';
+import {
+  CommonAvatar,
+  CommonButton,
+  CommonDivider,
+  CommonIcon,
+  CommonIconButton,
+  CommonMenu,
+  CommonText,
+  DividerImage,
+  Footer,
+  Header,
+} from '@/shared/components';
+import {
+  Container,
+  MemberInfoWrapper,
+  MemberIntroWrapper,
+  MemberInfoPanel,
+  MemberInfoBox,
+  ContentsWrapper,
+  ContentsPanel,
+  SubTitleBox,
+  ImagePanel,
+} from './style';
 
 const MemberHome = () => {
   const { memberId } = useParams();
 
-  return <>{memberId}</>;
+  return (
+    <>
+      <Header type="logo" />
+      <Container>
+        <MemberInfoWrapper>
+          <MemberInfoPanel>
+            <CommonAvatar size="5rem" />
+            <MemberInfoBox>
+              <CommonText type="strongInfo">LV. 10</CommonText>
+              <CommonText type="smallTitle">{memberId}</CommonText>
+              <CommonButton type="profile">프로필 수정</CommonButton>
+            </MemberInfoBox>
+          </MemberInfoPanel>
+          <CommonMenu type="logout" iconSize="0.3rem" onDelete={() => {}} />
+        </MemberInfoWrapper>
+        <MemberIntroWrapper>
+          <CommonText type="normalInfo" noOfLines={3}>
+            안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요
+          </CommonText>
+        </MemberIntroWrapper>
+        <CommonDivider size="lg" />
+        <ContentsWrapper>
+          <ContentsPanel>
+            <div>
+              <SubTitleBox>
+                <CommonIcon type="inventory" />
+                <CommonText type="smallTitle">인벤토리</CommonText>
+              </SubTitleBox>
+              <CommonText type="smallInfo">
+                취미별 아이템을 조합하여 나만의 인벤토리을 만들 수 있어요
+              </CommonText>
+            </div>
+            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+          </ContentsPanel>
+          <ImagePanel>
+            <DividerImage type="base" images={['1', '2', '3']} />
+            <DividerImage type="base" images={['1', '2', '3']} />
+            <DividerImage type="base" images={['1', '2', '3']} />
+          </ImagePanel>
+        </ContentsWrapper>
+        <CommonDivider size="sm" />
+        <ContentsWrapper>
+          <ContentsPanel>
+            <div>
+              <SubTitleBox>
+                <CommonIcon type="bucket" />
+                <CommonText type="smallTitle">버킷</CommonText>
+              </SubTitleBox>
+              <CommonText type="smallInfo">
+                취미별 아이템을 조합하여 나만의 버킷을 만들 수 있어요
+              </CommonText>
+            </div>
+            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+          </ContentsPanel>
+          <ImagePanel>
+            <DividerImage type="base" images={['1', '2', '3']} />
+            <DividerImage type="base" images={['1', '2', '3']} />
+            <DividerImage type="base" images={['1', '2', '3']} />
+          </ImagePanel>
+        </ContentsWrapper>
+        <CommonDivider size="sm" />
+        <ContentsWrapper>
+          <ContentsPanel>
+            <div>
+              <SubTitleBox>
+                <CommonIcon type="feed" />
+                <CommonText type="smallTitle">피드</CommonText>
+              </SubTitleBox>
+              <CommonText type="smallInfo">
+                내가 올린 피드와 좋아요한 피드를 확인할 수 있어요
+              </CommonText>
+            </div>
+            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+          </ContentsPanel>
+        </ContentsWrapper>
+        <CommonDivider size="sm" />
+      </Container>
+      <Footer />
+    </>
+  );
 };
 
 export default MemberHome;

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -1,0 +1,53 @@
+export const Container = styled.div`
+  height: 100%;
+`;
+import styled from '@emotion/styled';
+
+export const MemberInfoWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0 3rem;
+`;
+
+export const MemberInfoPanel = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+`;
+
+export const MemberInfoBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  & button {
+    margin-top: 0.4rem;
+  }
+`;
+
+export const MemberIntroWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 3rem;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1rem 1rem 1.5rem;
+`;
+
+export const ContentsPanel = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const SubTitleBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const ImagePanel = styled.div`
+  display: flex;
+  gap: 1rem;
+  padding-top: 1rem;
+`;

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -1,7 +1,8 @@
+import styled from '@emotion/styled';
+
 export const Container = styled.div`
   height: 100%;
 `;
-import styled from '@emotion/styled';
 
 export const MemberInfoWrapper = styled.div`
   display: flex;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,3 +2,4 @@ export { default as FeedCreate } from './Feed/FeedCreate';
 export { default as FeedDetail } from './Feed/FeedDetail';
 export { default as FeedHome } from './Feed/FeedHome';
 export { default as Home } from './Home';
+export { default as MemberHome } from './Member/MemberHome';

--- a/src/shared/components/Avatar/index.tsx
+++ b/src/shared/components/Avatar/index.tsx
@@ -2,10 +2,10 @@ import { Box, Avatar, AvatarProps, Circle } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
 interface CommonAvatarProps {
-  isOwner: boolean;
-  size: string;
-  src: AvatarProps['src'];
-  onClick: () => void;
+  isOwner?: boolean;
+  size?: string;
+  src?: AvatarProps['src'];
+  onClick?: () => void;
 }
 
 const CommonAvatar = ({
@@ -14,6 +14,10 @@ const CommonAvatar = ({
   src = 'https://bit.ly/broken-link',
   onClick,
 }: CommonAvatarProps) => {
+  const handleClick = () => {
+    onClick && onClick();
+  };
+
   return (
     <>
       {isOwner ? (
@@ -25,14 +29,14 @@ const CommonAvatar = ({
             position="absolute"
             top="6.165rem"
             right="0.45rem"
-            onClick={onClick}
+            onClick={handleClick}
           >
             <CommonIcon type="pen" />
           </Circle>
         </Box>
       ) : (
         <Box>
-          <Avatar src={src} width={size} height={size} onClick={onClick} />
+          <Avatar src={src} width={size} height={size} onClick={handleClick} />
         </Box>
       )}
     </>

--- a/src/shared/components/Avatar/index.tsx
+++ b/src/shared/components/Avatar/index.tsx
@@ -2,10 +2,10 @@ import { Box, Avatar, AvatarProps, Circle } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
 interface CommonAvatarProps {
-  isOwner?: boolean;
-  size?: string;
-  src?: AvatarProps['src'];
-  onClick?: () => void;
+  isOwner: boolean;
+  size: string;
+  src: AvatarProps['src'];
+  onClick: () => void;
 }
 
 const CommonAvatar = ({
@@ -13,7 +13,7 @@ const CommonAvatar = ({
   size,
   src = 'https://bit.ly/broken-link',
   onClick,
-}: CommonAvatarProps) => {
+}: Partial<CommonAvatarProps>) => {
   const handleClick = () => {
     onClick && onClick();
   };

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -12,7 +12,8 @@ interface CommonButtonProps {
     | 'text'
     | 'smText'
     | 'xsText'
-    | 'custom';
+    | 'custom'
+    | 'profile';
   isClick?: boolean;
   isDisabled?: boolean;
   children?: string;
@@ -181,6 +182,19 @@ const CommonButton = ({
       >
         <CommonIcon type="plus" />
       </Box>
+    ),
+    profile: (
+      <Button
+        size="xs"
+        bg="gray.100"
+        color="gray.800"
+        width="fit-content"
+        onClick={handleClick}
+        isDisabled={isDisabled}
+        type={isSubmit ? 'submit' : 'button'}
+      >
+        {children}
+      </Button>
     ),
   };
 

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -29,7 +29,7 @@ const FOOTER_INFO = [
 ];
 
 interface FooterProps {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 type FooterIcon = 'home' | 'search' | 'bucket' | 'item' | 'user';


### PR DESCRIPTION
## 구현(수정) 내용
MemberHome 페이지를 구현했습니다.
UI 우선으로 구현하였고 추후에 기능을 구현하겠습니다.

router의 path 중 user로 작성되어진 부분을 member로 변경하였습니다. 

CommonButton, Avatar 컴포넌트의 타입 중 일부를 옵셔널 타입으로 수정했습니다.

CommonButton 컴포넌트에 profile 버튼 타입을 추가했습니다.

## 스크린샷
![스크린샷 2023-11-16 오전 1 26 01](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/f7ff3dec-a078-4240-82cb-b37feb2e311a)

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
