### PR TITLE
[OMCT-254] MemberPassword 페이지 UI 구현

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -17,6 +17,7 @@ import {
   Login,
   Signup,
   MemberEdit,
+  MemberPassword,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -96,7 +97,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'member/edit/password',
-        element: <div>member edit password</div>,
+        element: <MemberPassword />,
       },
       {
         path: 'member/:memberId',

--- a/src/pages/Member/MemberPassword/index.tsx
+++ b/src/pages/Member/MemberPassword/index.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { CommonButton, CommonIcon, CommonInput, CommonText, Header } from '@/shared/components';
+import { Container, FormWrapper, InputPanel } from './style';
+
+const MemberPassword = () => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+
+  return (
+    <>
+      <Header type="back" />
+      <Container>
+        <CommonText type="normalTitle">비밀번호 변경</CommonText>
+        <FormWrapper>
+          <InputPanel>
+            <CommonInput
+              width="100%"
+              placeholder="비밀번호를 입력해주세요"
+              label="비밀번호"
+              type={showPassword ? 'text' : 'password'}
+              rightIcon={
+                <CommonIcon
+                  type={showPassword ? 'eye' : 'eyeSlash'}
+                  size="1.25rem"
+                  onClick={() => setShowPassword(!showPassword)}
+                />
+              }
+            />
+            <CommonInput
+              width="100%"
+              placeholder="비밀번호를 확인해주세요"
+              type={showPasswordConfirm ? 'text' : 'password'}
+              rightIcon={
+                <CommonIcon
+                  type={showPasswordConfirm ? 'eye' : 'eyeSlash'}
+                  size="1.25rem"
+                  onClick={() => setShowPasswordConfirm(!showPasswordConfirm)}
+                />
+              }
+            />
+          </InputPanel>
+          <CommonButton type="mdMiddle" isSubmit={true}>
+            변경하기
+          </CommonButton>
+        </FormWrapper>
+      </Container>
+    </>
+  );
+};
+
+export default MemberPassword;

--- a/src/pages/Member/MemberPassword/style.tsx
+++ b/src/pages/Member/MemberPassword/style.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  height: 100%;
+  padding: 0 3.5rem;
+`;
+
+export const FormWrapper = styled.form`
+  height: 90%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const InputPanel = styled.div`
+  height: 50%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -14,3 +14,4 @@ export { default as VoteHome } from './Vote/VoteHome';
 export { default as Login } from './Member/Login';
 export { default as Signup } from './Member/Signup';
 export { default as MemberEdit } from './Member/MemberEdit';
+export { default as MemberPassword } from './Member/MemberPassword';

--- a/src/shared/components/Icon/index.tsx
+++ b/src/shared/components/Icon/index.tsx
@@ -65,10 +65,15 @@ interface CommonIconProps {
   type: keyof typeof ICONS;
   size?: string;
   color?: string;
+  onClick?: () => void;
 }
 
-const CommonIcon = ({ type, size, color }: CommonIconProps) => {
-  return <Icon as={ICONS[type]} boxSize={size} color={color} height="100%" />;
+const CommonIcon = ({ type, size, color, onClick }: CommonIconProps) => {
+  const handleClick = () => {
+    onClick && onClick();
+  };
+
+  return <Icon as={ICONS[type]} boxSize={size} color={color} height="100%" onClick={handleClick} />;
 };
 
 export default CommonIcon;


### PR DESCRIPTION
## 구현(수정) 내용
MemberPassword 페이지의 UI를 구현했습니다.

## 스크린샷
![스크린샷 2023-11-19 오전 3 03 55](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/3d0e293b-7722-48d0-a8f7-0940e1462688)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
