### PR TITLE
[OMCT-180] 투표 상세페이지 get api 연동

### DIFF
--- a/src/features/vote/components/VoteItem/index.tsx
+++ b/src/features/vote/components/VoteItem/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { CommonCard, CommonImage, CommonText } from '@/shared/components';
 import { ItemInfo, VoteInfo } from '@/shared/types';
 import { ContentsContainer, ContentsWrapper, VoteImageWrapper, VsBox } from './style';
@@ -9,8 +10,16 @@ interface VoteItemProps {
 }
 
 const VoteItem = ({ item1Info, item2Info, voteInfo }: VoteItemProps) => {
+  const navigate = useNavigate();
+
   return (
-    <CommonCard count={voteInfo.participants} date={voteInfo.startTime} onClick={() => {}}>
+    <CommonCard
+      count={voteInfo.participants}
+      date={voteInfo.startTime}
+      onClick={() => {
+        navigate(`${voteInfo.id}`);
+      }}
+    >
       <ContentsContainer>
         <CommonText type="smallInfo">{voteInfo.content}</CommonText>
         <ContentsWrapper>

--- a/src/features/vote/components/VoteOptionItem/index.tsx
+++ b/src/features/vote/components/VoteOptionItem/index.tsx
@@ -1,39 +1,29 @@
-import { Box, Button, Flex } from '@chakra-ui/react';
 import { CommonImage, CommonText } from '@/shared/components';
+import { ItemInfo } from '@/shared/types';
+import { Button, ItemWrapper, TextWrapper } from './style';
 
 interface VoteOptionItemProps {
   onClick?: () => void;
+  itemInfo?: ItemInfo;
+  votes?: number;
 }
 
-const VoteOptionItem = ({ onClick }: VoteOptionItemProps) => {
+const VoteOptionItem = ({ onClick, itemInfo, votes }: VoteOptionItemProps) => {
   const handleClick = () => {
     onClick && onClick();
   };
 
   return (
-    <Box>
-      <Flex flexDir="column" pos="relative">
-        <CommonImage size="lg" src="" />
-        <Button
-          pos="absolute"
-          bottom="-2rem"
-          right="40%"
-          color="white"
-          bgColor="blue.300"
-          borderRadius="50%"
-          w="4.0625rem"
-          h="4.0625rem"
-          onClick={handleClick}
-        >
-          10
-        </Button>
-      </Flex>
-
-      <Flex flexDir="column">
-        <CommonText type="smallTitle">29,800</CommonText>
-        <CommonText type="smallInfo">아이템 이름입니다.</CommonText>
-      </Flex>
-    </Box>
+    <div>
+      <ItemWrapper>
+        <CommonImage size="lg" src={itemInfo?.image} />
+        <Button onClick={handleClick}>{votes}</Button>
+      </ItemWrapper>
+      <TextWrapper>
+        <CommonText type="smallTitle">{itemInfo?.price}</CommonText>
+        <CommonText type="smallInfo">{itemInfo?.name}</CommonText>
+      </TextWrapper>
+    </div>
   );
 };
 

--- a/src/features/vote/components/VoteOptionItem/index.tsx
+++ b/src/features/vote/components/VoteOptionItem/index.tsx
@@ -1,23 +1,26 @@
+import { MouseEvent } from 'react';
 import { CommonImage, CommonText } from '@/shared/components';
 import { ItemInfo } from '@/shared/types';
 import { Button, ItemWrapper, TextWrapper } from './style';
 
 interface VoteOptionItemProps {
-  onClick?: () => void;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
   itemInfo?: ItemInfo;
   votes?: number;
 }
 
 const VoteOptionItem = ({ onClick, itemInfo, votes }: VoteOptionItemProps) => {
-  const handleClick = () => {
-    onClick && onClick();
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick && onClick(e);
   };
 
   return (
     <div>
       <ItemWrapper>
         <CommonImage size="lg" src={itemInfo?.image} />
-        <Button onClick={handleClick}>{votes}</Button>
+        <Button value={itemInfo?.id} type="button" onClick={(e) => handleClick(e)}>
+          {votes}
+        </Button>
       </ItemWrapper>
       <TextWrapper>
         <CommonText type="smallTitle">{itemInfo?.price}</CommonText>

--- a/src/features/vote/components/VoteOptionItem/style.ts
+++ b/src/features/vote/components/VoteOptionItem/style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { COMMON } from '@/shared/styles/Common';
+
+export const ItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+`;
+
+export const Button = styled.button`
+  position: absolute;
+  bottom: -2rem;
+  right: 40%;
+  color: white;
+  border-radius: 50%;
+  width: 4.0625rem;
+  height: 4.0625rem;
+  background-color: ${COMMON.COLORS.MAIN_COLOR};
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 2rem;
+  gap: 0.3rem;
+`;

--- a/src/features/vote/hooks/index.ts
+++ b/src/features/vote/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useDeleteVote } from './useDeleteVote';
+export { default as useParticipationVote } from './useParticipationVote';

--- a/src/features/vote/hooks/useDeleteVote.ts
+++ b/src/features/vote/hooks/useDeleteVote.ts
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import voteApi from '../service/handler';
+
+const useDeleteVote = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: voteApi.deleteVote,
+    onSuccess: () => {
+      navigate('/vote');
+    },
+  });
+};
+
+export default useDeleteVote;

--- a/src/features/vote/hooks/useParticipationVote.ts
+++ b/src/features/vote/hooks/useParticipationVote.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import voteApi from '../service/handler';
+
+const useDeleteVote = () => {
+  return useMutation({
+    mutationFn: voteApi.postVoteParticipation,
+    onSuccess: () => {},
+  });
+};
+
+export default useDeleteVote;

--- a/src/features/vote/service/queryOption.ts
+++ b/src/features/vote/service/queryOption.ts
@@ -1,0 +1,18 @@
+import { queryOptions } from '@tanstack/react-query';
+import { GetVotesRequest, voteApi } from '.';
+
+const voteQueryOption = {
+  all: ['vote'] as const,
+  list: ({ hobby, sort = 'recent', status, cursorId, size }: GetVotesRequest) =>
+    queryOptions({
+      queryKey: [...voteQueryOption.all, hobby, status, sort] as const,
+      queryFn: () => voteApi.getVotes({ hobby, sort, status, cursorId, size }),
+    }),
+  detail: (voteId: number) =>
+    queryOptions({
+      queryKey: [...voteQueryOption.all, voteId] as const,
+      queryFn: () => voteApi.getVoteDetail(voteId),
+    }),
+};
+
+export default voteQueryOption;

--- a/src/pages/Vote/VoteDetail/index.tsx
+++ b/src/pages/Vote/VoteDetail/index.tsx
@@ -1,8 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
 import { CommonIconButton, CommonText, DateText, Header } from '@/shared/components';
 import { Body, Content, Footer, Span, Title } from './style';
 import { VoteOptionItem } from '@/features/vote/components';
+import voteQueryOption from '@/features/vote/service/queryOption';
 
 const VoteDetail = () => {
+  const { data: voteDetailData } = useQuery({ ...voteQueryOption.detail(6) });
   const deleteVoteDetail = () => {};
 
   return (
@@ -11,22 +14,28 @@ const VoteDetail = () => {
       <Body>
         <Title>
           <CommonText type="normalTitle" noOfLines={0}>
-            진행중인 투표
+            {voteDetailData?.voteInfo.isVoting ? '진행중인 투표' : '종료된 투표'}
           </CommonText>
-          <CommonIconButton type="delete" onClick={deleteVoteDetail} />
+          {voteDetailData?.isOwner && <CommonIconButton type="delete" onClick={deleteVoteDetail} />}
         </Title>
         <CommonText type="smallInfo" noOfLines={0}>
-          이거 엄마한테 선물드릴려고 하는데 뭐가 더 좋아?
+          {voteDetailData?.voteInfo.content}
         </CommonText>
         <Content>
-          <VoteOptionItem />
+          <VoteOptionItem
+            itemInfo={voteDetailData?.item1Info}
+            votes={voteDetailData?.voteInfo.item1Votes}
+          />
           <Span>VS</Span>
-          <VoteOptionItem />
+          <VoteOptionItem
+            itemInfo={voteDetailData?.item2Info}
+            votes={voteDetailData?.voteInfo.item2Votes}
+          />
         </Content>
         <Footer>
-          <DateText createdDate="2023-11-10T07:35:32.716Z" />
+          <DateText createdDate={voteDetailData?.voteInfo.startTime || ''} />
           <CommonText type="smallInfo" noOfLines={0}>
-            00명 참여
+            {voteDetailData?.voteInfo.participants}명 참여
           </CommonText>
         </Footer>
       </Body>

--- a/src/pages/Vote/VoteDetail/index.tsx
+++ b/src/pages/Vote/VoteDetail/index.tsx
@@ -1,12 +1,26 @@
+import { MouseEvent } from 'react';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { CommonIconButton, CommonText, DateText, Header } from '@/shared/components';
 import { Body, Content, Footer, Span, Title } from './style';
 import { VoteOptionItem } from '@/features/vote/components';
+import { useDeleteVote, useParticipationVote } from '@/features/vote/hooks';
 import voteQueryOption from '@/features/vote/service/queryOption';
 
 const VoteDetail = () => {
-  const { data: voteDetailData } = useQuery({ ...voteQueryOption.detail(6) });
-  const deleteVoteDetail = () => {};
+  const { voteId } = useParams();
+  const { data: voteDetailData } = useQuery({ ...voteQueryOption.detail(Number(voteId)) });
+  const { mutate: DeleteVoteMutate } = useDeleteVote();
+  const { mutate: ParticipationVoteMutate } = useParticipationVote();
+
+  const deleteVoteDetail = () => {
+    // 정말 삭제할것인지 모달창을 띄워줘야하나?
+    DeleteVoteMutate(Number(voteId)); // 추후 파라미터에서 id값을 받아와서 입력
+  };
+  const toggleVoteParticipation = (e: MouseEvent<HTMLButtonElement>) => {
+    const { value } = e.currentTarget;
+    ParticipationVoteMutate({ voteId: Number(voteId), itemId: Number(value) });
+  };
 
   return (
     <>
@@ -25,11 +39,13 @@ const VoteDetail = () => {
           <VoteOptionItem
             itemInfo={voteDetailData?.item1Info}
             votes={voteDetailData?.voteInfo.item1Votes}
+            onClick={toggleVoteParticipation}
           />
           <Span>VS</Span>
           <VoteOptionItem
             itemInfo={voteDetailData?.item2Info}
             votes={voteDetailData?.voteInfo.item2Votes}
+            onClick={toggleVoteParticipation}
           />
         </Content>
         <Footer>

--- a/src/pages/Vote/VoteDetail/index.tsx
+++ b/src/pages/Vote/VoteDetail/index.tsx
@@ -5,7 +5,7 @@ import { CommonIconButton, CommonText, DateText, Header } from '@/shared/compone
 import { Body, Content, Footer, Span, Title } from './style';
 import { VoteOptionItem } from '@/features/vote/components';
 import { useDeleteVote, useParticipationVote } from '@/features/vote/hooks';
-import voteQueryOption from '@/features/vote/service/queryOption';
+import { voteQueryOption } from '@/features/vote/service';
 
 const VoteDetail = () => {
   const { voteId } = useParams();


### PR DESCRIPTION
## 구현(수정) 내용
투표 상세페이지에 get api를 연동했습니다.
투표 참여하는거까지하려고했는데 테스트하는도중 api가 이상한것같아서 나머지는 추후에 나눠서 pr을 올려야할것같습니다!

## 스크린샷

https://github.com/bucket-back/bucket-back-frontend/assets/104294861/2303347e-c74a-4790-a351-fce1b2fc73e2



## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
