### PR TITLE
[OMCT-285] 피드 상세 페이지 수정 및 좋아요 기능 추가

### DIFF
--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
 import { FeedItemInfo, MemberInfo } from '@/shared/types';
-import { useFeedLike } from '../../hooks';
+import { useFeedLike, useFeedUnLike } from '../../hooks';
 import {
   Container,
   ProfileWrapper,
@@ -60,10 +60,13 @@ const FeedItem = ({
   const userInfo = useUserInfo();
 
   const feedLike = useFeedLike();
+  const feedUnLike = useFeedUnLike();
 
   const handleClickLike = () => {
     if (!isLike) {
       feedLike.mutate(feedId);
+    } else {
+      feedUnLike.mutate(feedId);
     }
   };
 

--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -7,7 +7,9 @@ import {
   CommonMenu,
   CommonButton,
 } from '@/shared/components';
+import { useUserInfo } from '@/shared/hooks';
 import { FeedItemInfo, MemberInfo } from '@/shared/types';
+import { useFeedLike } from '../../hooks';
 import {
   Container,
   ProfileWrapper,
@@ -55,6 +57,16 @@ const FeedItem = ({
   onUpdate,
   onDelete,
 }: FeedItemProps) => {
+  const userInfo = useUserInfo();
+
+  const feedLike = useFeedLike();
+
+  const handleClickLike = () => {
+    if (!isLike) {
+      feedLike.mutate(feedId);
+    }
+  };
+
   return (
     <Container>
       <ProfileWrapper>
@@ -64,7 +76,7 @@ const FeedItem = ({
           levelNumber={memberInfo.level}
           isAdopted={false}
         />
-        {isDetail && (
+        {isDetail && userInfo?.nickname === memberInfo.nickName && (
           <CommonMenu
             type="update"
             iconSize="0.35rem"
@@ -73,9 +85,9 @@ const FeedItem = ({
           />
         )}
       </ProfileWrapper>
-      <ContentsWrapper onClick={() => onClick && onClick(feedId)}>
+      <ContentsWrapper>
         {feedContent && (
-          <CommonText type="smallInfo" color="inherit" noOfLines={isDetail ? 10 : 3}>
+          <CommonText type="normalInfo" color="inherit" noOfLines={isDetail ? 10 : 3}>
             {feedContent}
           </CommonText>
         )}
@@ -85,7 +97,7 @@ const FeedItem = ({
             <CommonText type="normalInfo">{bucketBudget}원</CommonText>
           </BucketInfoBox>
         )}
-        <ImageBox>
+        <ImageBox onClick={() => onClick(feedId)}>
           {feedItems.map((item) => (
             <CommonImage key={item.id} size="sm" src={item.image} />
           ))}
@@ -94,7 +106,9 @@ const FeedItem = ({
           <DateText createdDate={createdAt} />
           <InteractPanel>
             {isDetail ? (
-              <CommonButton type="sm">{String(likeCount)}</CommonButton>
+              <CommonButton type="sm" isLike={isLike} onClick={handleClickLike}>
+                {String(likeCount)}
+              </CommonButton>
             ) : (
               <>
                 <LikeBox>

--- a/src/features/feed/components/FeedItem/style.tsx
+++ b/src/features/feed/components/FeedItem/style.tsx
@@ -35,6 +35,7 @@ export const ImageBox = styled.div`
 export const DetailInfoWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 0 0.5rem;
 `;
 

--- a/src/features/feed/components/FeedItemsDetail/index.tsx
+++ b/src/features/feed/components/FeedItemsDetail/index.tsx
@@ -1,13 +1,20 @@
+import { useNavigate } from 'react-router-dom';
 import { CommonButton, CommonImage } from '@/shared/components';
 import { FeedItemInfo } from '@/shared/types';
+import { ellipsisName } from '@/shared/utils';
 import { ButtonBox, Container, ContentsWrapper } from './style';
 
 interface FeedItemsDetailProps {
   items?: FeedItemInfo[];
-  onClick?: () => void;
 }
 
-const FeedItemsDetail = ({ items, onClick }: FeedItemsDetailProps) => {
+const FeedItemsDetail = ({ items }: FeedItemsDetailProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = (id: number) => {
+    navigate(`/item/${id}`);
+  };
+
   return (
     <Container>
       {items &&
@@ -15,11 +22,11 @@ const FeedItemsDetail = ({ items, onClick }: FeedItemsDetailProps) => {
           <ContentsWrapper key={id}>
             <ButtonBox>
               <CommonImage size="xs" src={image} />
-              <CommonButton type="xs" onClick={onClick}>
-                {name}
+              <CommonButton type="xs" onClick={() => handleClick(id)}>
+                {ellipsisName(name)}
               </CommonButton>
             </ButtonBox>
-            <CommonImage size="lg" src={image} onClick={onClick} />
+            <CommonImage size="lg" src={image} onClick={() => handleClick(id)} />
           </ContentsWrapper>
         ))}
     </Container>

--- a/src/features/feed/hooks/index.ts
+++ b/src/features/feed/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useFeedLike } from './useFeedLike';
+export { default as useFeedUnLike } from './useFeedUnLike';

--- a/src/features/feed/hooks/index.ts
+++ b/src/features/feed/hooks/index.ts
@@ -1,2 +1,1 @@
-export { default as useFeeds } from './useFeeds';
-export { default as useFeedDetail } from './useFeedDetail';
+export { default as useFeedLike } from './useFeedLike';

--- a/src/features/feed/hooks/useFeedDetail.ts
+++ b/src/features/feed/hooks/useFeedDetail.ts
@@ -1,8 +1,0 @@
-import { useQuery } from '@tanstack/react-query';
-import { feedQueryOption } from '../service';
-
-const useFeedDetail = (feedId: number) => {
-  return useQuery(feedQueryOption.detail(feedId));
-};
-
-export default useFeedDetail;

--- a/src/features/feed/hooks/useFeedLike.ts
+++ b/src/features/feed/hooks/useFeedLike.ts
@@ -1,13 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
 import { feedApi, feedQueryOption } from '../service';
 
 const useFeedLike = () => {
   const queryClient = useQueryClient();
+  const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: feedApi.postFeedLike,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: feedQueryOption.all });
+    },
+    onError: () => {
+      openToast({ message: '로그인후 이용가능합니다.', type: 'info' });
     },
   });
 };

--- a/src/features/feed/hooks/useFeedLike.ts
+++ b/src/features/feed/hooks/useFeedLike.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { feedApi, feedQueryOption } from '../service';
+
+const useFeedLike = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: feedApi.postFeedLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: feedQueryOption.all });
+    },
+  });
+};
+
+export default useFeedLike;

--- a/src/features/feed/hooks/useFeedUnLike.ts
+++ b/src/features/feed/hooks/useFeedUnLike.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { feedApi, feedQueryOption } from '../service';
+
+const useFeedUnLike = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: feedApi.deleteFeedLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: feedQueryOption.all });
+    },
+  });
+};
+
+export default useFeedUnLike;

--- a/src/features/feed/hooks/useFeeds.ts
+++ b/src/features/feed/hooks/useFeeds.ts
@@ -1,8 +1,0 @@
-import { useQuery } from '@tanstack/react-query';
-import { GetFeedsRequest, feedQueryOption } from '../service';
-
-const useFeeds = ({ hobbyName, nickname, sortCondition, cursorId, size }: GetFeedsRequest) => {
-  return useQuery(feedQueryOption.list({ hobbyName, nickname, sortCondition, cursorId, size }));
-};
-
-export default useFeeds;

--- a/src/features/feed/service/queryOption.ts
+++ b/src/features/feed/service/queryOption.ts
@@ -3,7 +3,7 @@ import { GetFeedsRequest, feedApi } from '.';
 
 const feedQueryOption = {
   all: ['feed'] as const,
-  list: ({ hobbyName, nickname, sortCondition, cursorId, size }: GetFeedsRequest) =>
+  list: ({ hobbyName, nickname, sortCondition, cursorId, size = 10 }: GetFeedsRequest) =>
     queryOptions({
       queryKey: [...feedQueryOption.all, hobbyName] as const,
       queryFn: () => feedApi.getFeeds({ hobbyName, nickname, sortCondition, cursorId, size }),

--- a/src/features/feed/service/types.ts
+++ b/src/features/feed/service/types.ts
@@ -10,7 +10,7 @@ export interface GetFeedsRequest {
   nickname?: string;
   sortCondition?: 'popularity' | 'latest';
   cursorId?: string;
-  size: number;
+  size?: number;
 }
 
 export interface GetFeedDetailResponse {

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -22,19 +22,20 @@ import { CommentItem } from '@/features/comment/components';
 import useAddComment from '@/features/comment/hooks/useAddComment';
 import { PostCommentRequest, commentQueryQption } from '@/features/comment/service';
 import { FeedItemsDetail, FeedItem } from '@/features/feed/components';
-import { useFeedDetail } from '@/features/feed/hooks';
+import { feedQueryOption } from '@/features/feed/service';
 
 const FeedDetail = () => {
   const { isOpen, onOpen, onClose } = useDrawer();
   const { feedId } = useParams();
+  const feedIdNumber = Number(feedId);
 
-  const feed = useFeedDetail(Number(feedId));
-  const comment = useQuery(commentQueryQption.list({ feedId: Number(feedId) || 1, size: 10 }));
+  const feedDetail = useQuery(feedQueryOption.detail(feedIdNumber));
+  const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber || 1, size: 10 }));
 
   const { register, handleSubmit, reset } = useForm<PostCommentRequest>();
   const { mutate } = useAddComment();
   const onSubmit: SubmitHandler<PostCommentRequest> = (data) => {
-    mutate({ feedId: Number(feedId), content: data.content });
+    mutate({ feedId: feedIdNumber, content: data.content });
     reset();
   };
 
@@ -42,18 +43,18 @@ const FeedDetail = () => {
     <>
       <Header type="back" />
       <FeedDetailContainer>
-        {feed.isSuccess && (
+        {feedDetail.isSuccess && (
           <FeedItem
-            memberInfo={feed.data.memberInfo}
-            feedId={feed.data.feedInfo.id}
-            feedContent={feed.data.feedInfo.content}
-            isLike={feed.data.feedInfo.isLiked}
-            likeCount={feed.data.feedInfo.likeCount}
+            memberInfo={feedDetail.data.memberInfo}
+            feedId={feedDetail.data.feedInfo.id}
+            feedContent={feedDetail.data.feedInfo.content}
+            isLike={feedDetail.data.feedInfo.isLiked}
+            likeCount={feedDetail.data.feedInfo.likeCount}
             commentCount={comment.data?.totalCount || 0}
-            createdAt={feed.data.feedInfo.createdAt}
-            feedItems={feed.data.feedItems}
-            bucketName={feed.data.feedInfo.bucketName}
-            bucketBudget={feed.data.feedInfo.bucketBudget}
+            createdAt={feedDetail.data.feedInfo.createdAt}
+            feedItems={feedDetail.data.feedItems}
+            bucketName={feedDetail.data.feedInfo.bucketName}
+            bucketBudget={feedDetail.data.feedInfo.bucketBudget}
             isDetail
             onClick={onOpen}
           />
@@ -71,7 +72,7 @@ const FeedDetail = () => {
           comment.data.comments.map((data) => (
             <Fragment key={data.commentId}>
               <CommentItem
-                feedId={Number(feedId)}
+                feedId={feedIdNumber}
                 commentId={data.commentId}
                 memberInfo={data.memberInfo}
                 content={data.content}
@@ -101,7 +102,7 @@ const FeedDetail = () => {
       </CommentInputContainer>
 
       <CommonDrawer isOpen={isOpen} onClose={onClose} onClickFooterButton={onClose} isFull={true}>
-        <FeedItemsDetail items={feed.data?.feedItems} />
+        <FeedItemsDetail items={feedDetail.data?.feedItems} />
       </CommonDrawer>
     </>
   );

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -10,7 +10,7 @@ import {
   CommonText,
   Header,
 } from '@/shared/components';
-import { useDrawer } from '@/shared/hooks';
+import { useAuthCheck, useDrawer } from '@/shared/hooks';
 import {
   FeedDetailContainer,
   CommentNumberWrapper,
@@ -28,6 +28,7 @@ const FeedDetail = () => {
   const { isOpen, onOpen, onClose } = useDrawer();
   const { feedId } = useParams();
   const feedIdNumber = Number(feedId);
+  const isLogin = useAuthCheck();
 
   const feedDetail = useQuery(feedQueryOption.detail(feedIdNumber));
   const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber || 1, size: 10 }));
@@ -91,9 +92,10 @@ const FeedDetail = () => {
           size="md"
           type="text"
           width="100%"
-          placeholder="댓글을 입력해주세요"
+          placeholder={isLogin ? '댓글을 입력해주세요' : '로그인후 이용가능합니다'}
+          isDisabled={!isLogin}
           rightIcon={
-            <CommonButton isSubmit type="mdFull">
+            <CommonButton type="mdFull" isSubmit isDisabled={!isLogin}>
               등록
             </CommonButton>
           }

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -1,9 +1,10 @@
 import { useEffect, Fragment } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { CommonDivider, CommonTabs } from '@/shared/components';
 import { Container, NoResult } from './style';
 import { FeedItem } from '@/features/feed/components';
-import { useFeeds } from '@/features/feed/hooks';
+import { feedQueryOption } from '@/features/feed/service';
 import { useHobby } from '@/features/hobby/hooks';
 
 const FeedHome = () => {
@@ -17,10 +18,11 @@ const FeedHome = () => {
     }
   }, [hobbies.data?.hobbies, hobbies.isSuccess, searchParams, setSearchParams]);
 
-  const feeds = useFeeds({
-    hobbyName: searchParams.get('hobby') || hobbies.data?.hobbies[0].name || '',
-    size: 10,
-  });
+  const feeds = useQuery(
+    feedQueryOption.list({
+      hobbyName: searchParams.get('hobby') || hobbies.data?.hobbies[0].name || '',
+    })
+  );
 
   const currentTabIndex = hobbies.data?.hobbies
     .map(({ name }) => name)

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -24,7 +24,7 @@ import {
 } from './style';
 
 const MemberHome = () => {
-  const { memberId } = useParams();
+  const { nickname } = useParams();
 
   return (
     <>
@@ -35,7 +35,7 @@ const MemberHome = () => {
             <CommonAvatar size="5rem" />
             <MemberInfoBox>
               <CommonText type="strongInfo">LV. 10</CommonText>
-              <CommonText type="smallTitle">{memberId}</CommonText>
+              <CommonText type="smallTitle">{nickname}</CommonText>
               <CommonButton type="profile">프로필 수정</CommonButton>
             </MemberInfoBox>
           </MemberInfoPanel>

--- a/src/shared/components/Avatar/index.tsx
+++ b/src/shared/components/Avatar/index.tsx
@@ -36,7 +36,7 @@ const CommonAvatar = ({
         </Box>
       ) : (
         <Box>
-          <Avatar src={src} width={size} height={size} onClick={handleClick} />
+          <Avatar src={src} width={size} height={size} onClick={handleClick} cursor="pointer" />
         </Box>
       )}
     </>

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -20,6 +20,7 @@ interface CommonButtonProps {
   onClick?: () => void;
   isSubmit?: boolean;
   width?: string;
+  isLike?: boolean;
 }
 
 const CommonButton = ({
@@ -30,6 +31,7 @@ const CommonButton = ({
   onClick,
   isSubmit = false,
   width = '100%',
+  isLike,
 }: CommonButtonProps) => {
   const handleClick = () => {
     onClick && onClick();
@@ -103,7 +105,7 @@ const CommonButton = ({
         borderColor="blue.300"
         bg={isClick ? 'blue.300' : undefined}
         color={isClick ? 'white' : 'blue.300'}
-        leftIcon={<CommonIcon type="heart" />}
+        leftIcon={<CommonIcon type={isLike ? 'fillHeart' : 'heart'} />}
         onClick={handleClick}
         isDisabled={isDisabled}
         type={isSubmit ? 'submit' : 'button'}

--- a/src/shared/components/Input/index.tsx
+++ b/src/shared/components/Input/index.tsx
@@ -20,6 +20,7 @@ interface CommonInputProps {
   rightIcon?: ReactElement;
   size?: 'sm' | 'md' | 'lg';
   width?: string;
+  isDisabled?: boolean;
 }
 
 const CommonInput = forwardRef(
@@ -33,6 +34,7 @@ const CommonInput = forwardRef(
       type,
       size = 'md',
       width = '18.4375rem',
+      isDisabled = false,
       ...props
     }: CommonInputProps,
     ref
@@ -42,7 +44,13 @@ const CommonInput = forwardRef(
         {label && <FormLabel>{label}</FormLabel>}
         <InputGroup width={width} size={size}>
           {leftIcon && <InputLeftElement>{leftIcon}</InputLeftElement>}
-          <Input placeholder={placeholder} ref={ref} {...props} type={type} />
+          <Input
+            placeholder={placeholder}
+            ref={ref}
+            {...props}
+            type={type}
+            isDisabled={isDisabled}
+          />
           {rightIcon && <InputRightElement>{rightIcon}</InputRightElement>}
         </InputGroup>
         {error?.message && <FormErrorMessage>{error.message}</FormErrorMessage>}

--- a/src/shared/components/Profile/index.tsx
+++ b/src/shared/components/Profile/index.tsx
@@ -13,14 +13,13 @@ const Profile = ({ nickname, src, levelNumber, isAdopted }: ProfileProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    // 추후 프로필로 이동
     navigate(`/member/${nickname}`);
   };
 
   return (
     <Flex alignItems="center">
       <CommonAvatar isOwner={false} size="3rem" onClick={handleClick} src={src} />
-      <Box ml="0.8rem">
+      <Box ml="0.8rem" onClick={handleClick} cursor="pointer">
         <CommonText type="smallTitle" color="blue.900" noOfLines={1}>
           {nickname}
         </CommonText>

--- a/src/shared/utils/ellipsisName.ts
+++ b/src/shared/utils/ellipsisName.ts
@@ -1,0 +1,9 @@
+const ellipsisName = (name: string) => {
+  if (name.length > 25) {
+    return `${name.slice(0, 26)}...`;
+  }
+
+  return name;
+};
+
+export default ellipsisName;

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,3 +1,4 @@
 export { default as conformText } from './conformText';
 export { default as formatNumber } from './formatNumber';
 export { default as Storage } from './storage';
+export { default as ellipsisName } from './ellipsisName';


### PR DESCRIPTION
## 구현(수정) 내용
피드 상세 페이지를 수정했습니다.
기존에 useQuery로 만든 훅을 삭제하고 직접 사용하는 방식으로 변경했습니다.
좋아요 기능을 추가했습니다.

로그인 여부에 따른 좋아요, 댓글 사용을 제한했습니다.

추가적으로 자잘한 디자인 및 공통 컴포넌트를 수정했습니다.

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
