### PR TITLE
[OMCT-287] 멤버 페이지의 로그아웃, 탈퇴 기능 구현

### DIFF
--- a/src/features/member/hooks/index.ts
+++ b/src/features/member/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useLogin } from './useLogin';
 export { default as useCheckEmail } from './useCheckEmail';
 export { default as useCheckNickname } from './useCheckNickname';
 export { default as useSignup } from './useSignup';
+export { default as useLogout } from './useLogout';

--- a/src/features/member/hooks/index.ts
+++ b/src/features/member/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useCheckEmail } from './useCheckEmail';
 export { default as useCheckNickname } from './useCheckNickname';
 export { default as useSignup } from './useSignup';
 export { default as useLogout } from './useLogout';
+export { default as useLeave } from './useLeave';

--- a/src/features/member/hooks/useLeave.ts
+++ b/src/features/member/hooks/useLeave.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { TOKEN_KEY, USER_INFO_KEY, ROOT_PATH } from '@/shared/constants';
+import { useCustomToast } from '@/shared/hooks';
+import { Storage } from '@/shared/utils';
+import { memberApi } from '../service';
+
+const useLeave = () => {
+  const openToast = useCustomToast();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: memberApi.deleteMember,
+    onSuccess: () => {
+      Storage.removeLocalStoraged(USER_INFO_KEY);
+      Storage.removeLocalStoraged(TOKEN_KEY);
+      openToast({ message: '탈퇴 완료됐습니다.', type: 'success' });
+      navigate(ROOT_PATH);
+    },
+  });
+};
+
+export default useLeave;

--- a/src/features/member/hooks/useLogout.ts
+++ b/src/features/member/hooks/useLogout.ts
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
+import { ROOT_PATH, TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
 import { useCustomToast } from '@/shared/hooks';
 import { Storage } from '@/shared/utils';
 
@@ -11,7 +11,7 @@ const useLogout = () => {
     Storage.removeLocalStoraged(USER_INFO_KEY);
     Storage.removeLocalStoraged(TOKEN_KEY);
     openToast({ message: '로그아웃 되었습니다.', type: 'success' });
-    navigate('/');
+    navigate(ROOT_PATH);
   };
 };
 

--- a/src/features/member/hooks/useLogout.ts
+++ b/src/features/member/hooks/useLogout.ts
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+import { TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
+import { useCustomToast } from '@/shared/hooks';
+import { Storage } from '@/shared/utils';
+
+const useLogout = () => {
+  const openToast = useCustomToast();
+  const navigate = useNavigate();
+
+  return () => {
+    Storage.removeLocalStoraged(USER_INFO_KEY);
+    Storage.removeLocalStoraged(TOKEN_KEY);
+    openToast({ message: '로그아웃 되었습니다.', type: 'success' });
+    navigate('/');
+  };
+};
+
+export default useLogout;

--- a/src/features/member/service/index.ts
+++ b/src/features/member/service/index.ts
@@ -1,2 +1,3 @@
 export { default as memberApi } from './handler';
 export * from './types';
+export { default as memberQueryOption } from './queryOption';

--- a/src/features/member/service/queryOption.ts
+++ b/src/features/member/service/queryOption.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from '@tanstack/react-query';
+import { memberApi } from '.';
+
+const memberQueryOption = {
+  all: ['member'] as const,
+  detail: (nickname: string) =>
+    queryOptions({
+      queryKey: [...memberQueryOption.all, nickname] as const,
+      queryFn: () => memberApi.getMember(nickname),
+    }),
+};
+
+export default memberQueryOption;

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -26,7 +26,7 @@ import {
   SubTitleBox,
   ImagePanel,
 } from './style';
-import { useLogout } from '@/features/member/hooks';
+import { useLeave, useLogout } from '@/features/member/hooks';
 import { memberQueryOption } from '@/features/member/service';
 
 const MemberHome = () => {
@@ -38,6 +38,7 @@ const MemberHome = () => {
 
   const member = useQuery(memberQueryOption.detail(nickname!));
   const logout = useLogout();
+  const leave = useLeave();
 
   return (
     <>
@@ -141,9 +142,10 @@ const MemberHome = () => {
         onClickFooterButton={() => {
           if (selectedStatus === 'logout') {
             logout();
-          } else {
-            // TODO: 탈퇴 기능 추가
-            console.log('탈퇴');
+          }
+
+          if (selectedStatus === 'leave') {
+            leave.mutate();
           }
         }}
         isFull={false}

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -1,4 +1,5 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import {
   CommonAvatar,
   CommonButton,
@@ -11,6 +12,7 @@ import {
   Footer,
   Header,
 } from '@/shared/components';
+import { useAuthCheck } from '@/shared/hooks';
 import {
   Container,
   MemberInfoWrapper,
@@ -22,9 +24,16 @@ import {
   SubTitleBox,
   ImagePanel,
 } from './style';
+import { useLogout } from '@/features/member/hooks';
+import { memberQueryOption } from '@/features/member/service';
 
 const MemberHome = () => {
-  const { memberId } = useParams();
+  const { nickname } = useParams();
+  const isLogin = useAuthCheck();
+  const navigate = useNavigate();
+
+  const member = useQuery(memberQueryOption.detail(nickname!));
+  const logout = useLogout();
 
   return (
     <>
@@ -34,12 +43,23 @@ const MemberHome = () => {
           <MemberInfoPanel>
             <CommonAvatar size="5rem" />
             <MemberInfoBox>
-              <CommonText type="strongInfo">LV. 10</CommonText>
-              <CommonText type="smallTitle">{memberId}</CommonText>
-              <CommonButton type="profile">프로필 수정</CommonButton>
+              <CommonText type="strongInfo">LV. {member.data?.memberProfile.levelPoint}</CommonText>
+              <CommonText type="smallTitle">{nickname}</CommonText>
+              {isLogin && (
+                <CommonButton type="profile" onClick={() => navigate('/member/edit')}>
+                  프로필 수정
+                </CommonButton>
+              )}
             </MemberInfoBox>
           </MemberInfoPanel>
-          <CommonMenu type="logout" iconSize="0.3rem" onDelete={() => {}} />
+          {isLogin && (
+            <CommonMenu
+              type="logout"
+              iconSize="0.3rem"
+              onLogout={() => logout()}
+              onDelete={() => {}}
+            />
+          )}
         </MemberInfoWrapper>
         <MemberIntroWrapper>
           <CommonText type="normalInfo" noOfLines={3}>

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -48,7 +48,7 @@ const MemberHome = () => {
           <MemberInfoPanel>
             <CommonAvatar size="5rem" />
             <MemberInfoBox>
-              <CommonText type="strongInfo">LV. {member.data?.memberProfile.levelPoint}</CommonText>
+              <CommonText type="strongInfo">LV. {member.data?.memberProfile.level}</CommonText>
               <CommonText type="smallTitle">{nickname}</CommonText>
               {isLogin && (
                 <CommonButton type="profile" onClick={() => navigate('/member/edit')}>
@@ -74,7 +74,7 @@ const MemberHome = () => {
         </MemberInfoWrapper>
         <MemberIntroWrapper>
           <CommonText type="normalInfo" noOfLines={3}>
-            안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요
+            {member.data?.memberProfile.introduction}
           </CommonText>
         </MemberIntroWrapper>
         <CommonDivider size="lg" />

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   CommonAvatar,
   CommonButton,
   CommonDivider,
+  CommonDrawer,
   CommonIcon,
   CommonIconButton,
   CommonMenu,
@@ -12,7 +14,7 @@ import {
   Footer,
   Header,
 } from '@/shared/components';
-import { useAuthCheck } from '@/shared/hooks';
+import { useAuthCheck, useDrawer } from '@/shared/hooks';
 import {
   Container,
   MemberInfoWrapper,
@@ -31,6 +33,8 @@ const MemberHome = () => {
   const { nickname } = useParams();
   const isLogin = useAuthCheck();
   const navigate = useNavigate();
+  const { isOpen, onOpen, onClose } = useDrawer();
+  const [selectedStatus, setSelectedStatus] = useState<'leave' | 'logout'>('logout');
 
   const member = useQuery(memberQueryOption.detail(nickname!));
   const logout = useLogout();
@@ -56,8 +60,14 @@ const MemberHome = () => {
             <CommonMenu
               type="logout"
               iconSize="0.3rem"
-              onLogout={() => logout()}
-              onDelete={() => {}}
+              onLogout={() => {
+                setSelectedStatus('logout');
+                onOpen();
+              }}
+              onDelete={() => {
+                setSelectedStatus('leave');
+                onOpen();
+              }}
             />
           )}
         </MemberInfoWrapper>
@@ -124,6 +134,23 @@ const MemberHome = () => {
         <CommonDivider size="sm" />
       </Container>
       <Footer />
+
+      <CommonDrawer
+        isOpen={isOpen}
+        onClose={onClose}
+        onClickFooterButton={() => {
+          if (selectedStatus === 'logout') {
+            logout();
+          } else {
+            // TODO: 탈퇴 기능 추가
+            console.log('탈퇴');
+          }
+        }}
+        isFull={false}
+        isCloseButton={false}
+      >
+        {selectedStatus === 'logout' ? '정말로 로그아웃하시겠습니까?' : '정말로 탈퇴하시겠습니까?'}
+      </CommonDrawer>
     </>
   );
 };

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -19,6 +19,7 @@ export const MemberInfoPanel = styled.div`
 export const MemberInfoBox = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   & button {
     margin-top: 0.4rem;
   }

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './storage';

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './storage';
+export * from './path';

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -1,0 +1,1 @@
+export const ROOT_PATH = '/';

--- a/src/shared/constants/storage.ts
+++ b/src/shared/constants/storage.ts
@@ -1,0 +1,2 @@
+export const TOKEN_KEY = 'token';
+export const USER_INFO_KEY = 'userInfo';

--- a/src/shared/types/member.ts
+++ b/src/shared/types/member.ts
@@ -8,7 +8,7 @@ export interface MemberInfo {
 export interface MemberProfile {
   memberId: number;
   nickname: string;
-  levelPoint: number;
+  level: number;
   introduction: string;
 }
 

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -1,6 +1,6 @@
 const getLocalStoraged = (key: string) => {
   try {
-    const value = window.localStorage.getItem(key);
+    const value = localStorage.getItem(key);
 
     return value ? JSON.parse(value) : '';
   } catch (error) {
@@ -16,4 +16,12 @@ const setLocalStoraged = <T>(key: string, value: T) => {
   }
 };
 
-export default { getLocalStoraged, setLocalStoraged };
+const removeLocalStoraged = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default { getLocalStoraged, setLocalStoraged, removeLocalStoraged };


### PR DESCRIPTION
## 구현(수정) 내용
멤버 페이지의 로그아웃, 탈퇴 기능을 구현했습니다.

로그아웃은 useLogout 훅을 사용하여 작동하며,
탈퇴는 useLeave 훅을 사용하여 작동합니다.

2번이상 쓰이는 문자열은 상수로 만들어서 constants 폴더에 추가했습니다.

## 스크린샷
https://github.com/bucket-back/bucket-back-frontend/assets/40534414/e1e1df12-f3db-4c75-b1b0-8a9dd64fdbbb


<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
