### PR TITLE
[OMCT-290] 피드 페이지 select 추가

### DIFF
--- a/src/features/feed/service/queryOption.ts
+++ b/src/features/feed/service/queryOption.ts
@@ -3,9 +3,9 @@ import { GetFeedsRequest, feedApi } from '.';
 
 const feedQueryOption = {
   all: ['feed'] as const,
-  list: ({ hobbyName, nickname, sortCondition, cursorId, size = 10 }: GetFeedsRequest) =>
+  list: ({ hobbyName, nickname, sortCondition = 'RECENT', cursorId, size = 10 }: GetFeedsRequest) =>
     queryOptions({
-      queryKey: [...feedQueryOption.all, hobbyName] as const,
+      queryKey: [...feedQueryOption.all, hobbyName, sortCondition] as const,
       queryFn: () => feedApi.getFeeds({ hobbyName, nickname, sortCondition, cursorId, size }),
     }),
 

--- a/src/features/feed/service/types.ts
+++ b/src/features/feed/service/types.ts
@@ -8,7 +8,7 @@ export interface GetFeedsResponse {
 export interface GetFeedsRequest {
   hobbyName: string;
   nickname?: string;
-  sortCondition?: 'popularity' | 'latest';
+  sortCondition?: string;
   cursorId?: string;
   size?: number;
 }

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -21,7 +21,7 @@ const FeedHome = () => {
   const feeds = useQuery(
     feedQueryOption.list({
       hobbyName: searchParams.get('hobby') || hobbies.data?.hobbies[0].name || '',
-      // sortCondition: searchParams.get('sort') || 'recent',
+      sortCondition: searchParams.get('sort') || 'RECENT',
     })
   );
 
@@ -45,12 +45,13 @@ const FeedHome = () => {
             <Container>
               <SelectWrapper>
                 <CommonSelect
+                  selectedValue={searchParams.get('sort')?.toLowerCase()}
                   onChange={(e) => {
                     const sort = e.target.value;
 
                     setSearchParams({
                       hobby: searchParams.get('hobby') || '',
-                      sort,
+                      sort: sort.toUpperCase(),
                     });
                   }}
                 />

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, Fragment } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { CommonDivider, CommonTabs } from '@/shared/components';
-import { Container, NoResult } from './style';
+import { CommonDivider, CommonSelect, CommonTabs } from '@/shared/components';
+import { Container, NoResult, SelectWrapper } from './style';
 import { FeedItem } from '@/features/feed/components';
 import { feedQueryOption } from '@/features/feed/service';
 import { useHobby } from '@/features/hobby/hooks';
@@ -21,6 +21,7 @@ const FeedHome = () => {
   const feeds = useQuery(
     feedQueryOption.list({
       hobbyName: searchParams.get('hobby') || hobbies.data?.hobbies[0].name || '',
+      // sortCondition: searchParams.get('sort') || 'recent',
     })
   );
 
@@ -42,6 +43,18 @@ const FeedHome = () => {
           label: value,
           content: (
             <Container>
+              <SelectWrapper>
+                <CommonSelect
+                  onChange={(e) => {
+                    const sort = e.target.value;
+
+                    setSearchParams({
+                      hobby: searchParams.get('hobby') || '',
+                      sort,
+                    });
+                  }}
+                />
+              </SelectWrapper>
               {feeds.isSuccess && feeds.data.feeds.length > 0 ? (
                 feeds.data.feeds.map(
                   ({

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -14,7 +14,7 @@ const FeedHome = () => {
 
   useEffect(() => {
     if (!searchParams.get('hobby') && hobbies.isSuccess) {
-      setSearchParams({ hobby: hobbies.data.hobbies[0].name });
+      setSearchParams({ hobby: hobbies.data.hobbies[0].name, sort: 'RECENT' });
     }
   }, [hobbies.data?.hobbies, hobbies.isSuccess, searchParams, setSearchParams]);
 

--- a/src/pages/Feed/FeedHome/style.tsx
+++ b/src/pages/Feed/FeedHome/style.tsx
@@ -12,3 +12,10 @@ export const NoResult = styled.div`
   justify-content: center;
   align-items: center;
 `;
+
+export const SelectWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  padding-top: 1rem;
+  padding-right: 1.5rem;
+`;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -27,7 +27,7 @@ const Home = () => {
 
   useEffect(() => {
     if (pathname === ROOT_PATH) {
-      navigate(`${TABS.FEED.VALUE}?hobby=basketball`);
+      navigate(`${TABS.FEED.VALUE}`);
     }
   }, [navigate, pathname]);
 

--- a/src/shared/components/Select/index.tsx
+++ b/src/shared/components/Select/index.tsx
@@ -5,6 +5,7 @@ interface CommonSelectProps {
   width?: `${number}rem`;
   height?: `${number}rem`;
   fontSize?: `${number}rem`;
+  selectedValue?: string;
   onChange: ChangeEventHandler<HTMLSelectElement>;
 }
 
@@ -12,10 +13,11 @@ const CommonSelect = ({
   width = '6rem',
   height = '1.9rem',
   fontSize = '1rem',
+  selectedValue,
   onChange,
 }: CommonSelectProps) => {
   return (
-    <Select w={width} h={height} fontSize={fontSize} onChange={onChange}>
+    <Select w={width} h={height} fontSize={fontSize} value={selectedValue} onChange={onChange}>
       <option value="recent">최신순</option>
       <option value="popularity">인기순</option>
     </Select>


### PR DESCRIPTION
## 구현(수정) 내용
피드 페이지에 select를 추가했습니다.
최신순, 인기순으로 피드 목록을 확인할 수 있습니다.
새로고침시에도 현재 url의 쿼리스트링의 sort값을 확인해서 option을 지정해줍니다.

## 스크린샷
![스크린샷 2023-11-22 오후 5 21 20](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/e42df6f7-b303-4598-bb31-e2b257eaa7a1)
![스크린샷 2023-11-22 오후 5 21 41](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/088bf370-a55e-4e33-8d3c-ae93ac3d5c69)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
