### PR TITLE
[OMCT-292] 피드 작성자만 댓글 채택하기 버튼 보이게 수정

### DIFF
--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -11,6 +11,8 @@ interface CommentItemProps {
   createdAt: string;
   isAdopted: boolean;
   memberInfo: MemberInfo;
+  isOwnFeed: boolean;
+  hasAdoptedComment: boolean;
 }
 
 const CommentItem = ({
@@ -20,6 +22,8 @@ const CommentItem = ({
   createdAt,
   isAdopted,
   memberInfo,
+  isOwnFeed,
+  hasAdoptedComment,
 }: CommentItemProps) => {
   const userInfo = useUserInfo();
   const deletComment = useDeleteComment();
@@ -51,7 +55,8 @@ const CommentItem = ({
         <DateText createdDate={createdAt} />
         <InteractPanel>
           <CommonButton type="xsText">인벤토리</CommonButton>
-          <CommonButton type="xsText">채택하기</CommonButton>
+          {!hasAdoptedComment ||
+            (!isOwnFeed && <CommonButton type="xsText">채택하기</CommonButton>)}
         </InteractPanel>
       </ContentsWrapper>
     </Container>

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -10,7 +10,7 @@ import {
   CommonText,
   Header,
 } from '@/shared/components';
-import { useAuthCheck, useDrawer } from '@/shared/hooks';
+import { useAuthCheck, useDrawer, useUserInfo } from '@/shared/hooks';
 import {
   FeedDetailContainer,
   CommentNumberWrapper,
@@ -29,16 +29,17 @@ const FeedDetail = () => {
   const { feedId } = useParams();
   const feedIdNumber = Number(feedId);
   const isLogin = useAuthCheck();
+  const userInfo = useUserInfo();
 
   const feedDetail = useQuery(feedQueryOption.detail(feedIdNumber));
   const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber || 1, size: 10 }));
-
   const { register, handleSubmit, reset } = useForm<PostCommentRequest>();
   const { mutate } = useAddComment();
   const onSubmit: SubmitHandler<PostCommentRequest> = (data) => {
     mutate({ feedId: feedIdNumber, content: data.content });
     reset();
   };
+  const isOwnFeed = feedDetail.data?.memberInfo.nickName === userInfo?.nickname;
 
   return (
     <>
@@ -79,6 +80,8 @@ const FeedDetail = () => {
                 content={data.content}
                 createdAt={data.createdAt}
                 isAdopted={data.isAdopted}
+                isOwnFeed={isOwnFeed}
+                hasAdoptedComment={feedDetail.data?.feedInfo.hasAdoptedComment || false}
               />
               <CommonDivider size="sm" />
             </Fragment>


### PR DESCRIPTION
## 구현(수정) 내용
피드 작성자만 댓글 채택하기 버튼 보이게 수정했습니다.

피드에 채택된 댓글이 있으면 댓글의 채택하기 버튼을 안보이게 수정했습니다.

## 스크린샷
![스크린샷 2023-11-22 오후 6 16 17](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/e3708019-4e70-4bfa-aa11-ebcf1fed4998)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
