### PR TITLE
[OMCT-307] 멤버 페이지 수정

### DIFF
--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -36,7 +36,7 @@ interface FeedItemProps {
   feedItems: FeedItemInfo[];
   bucketName?: string;
   bucketBudget?: number;
-  totalPrice: number;
+  totalPrice?: number;
   isDetail: boolean;
   onClick: (id: number) => void;
   onUpdate?: (id: number) => void;
@@ -100,7 +100,9 @@ const FeedItem = ({
         {isDetail && (
           <BucketInfoBox>
             <CommonText type="normalInfo">{bucketName}</CommonText>
-            <CommonText type="normalInfo">버킷 총액: {formatNumber(totalPrice)}원</CommonText>
+            {totalPrice && (
+              <CommonText type="normalInfo">버킷 총액: {formatNumber(totalPrice)}원</CommonText>
+            )}
             {bucketBudget && (
               <CommonText type="normalInfo">예산: {formatNumber(bucketBudget)}원</CommonText>
             )}

--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
 import { FeedItemInfo, MemberInfo } from '@/shared/types';
+import { formatNumber } from '@/shared/utils';
 import { useFeedLike, useFeedUnLike } from '../../hooks';
 import {
   Container,
@@ -35,6 +36,7 @@ interface FeedItemProps {
   feedItems: FeedItemInfo[];
   bucketName?: string;
   bucketBudget?: number;
+  totalPrice: number;
   isDetail: boolean;
   onClick: (id: number) => void;
   onUpdate?: (id: number) => void;
@@ -52,6 +54,7 @@ const FeedItem = ({
   feedItems,
   bucketName,
   bucketBudget,
+  totalPrice,
   isDetail = false,
   onClick,
   onUpdate,
@@ -97,7 +100,10 @@ const FeedItem = ({
         {isDetail && (
           <BucketInfoBox>
             <CommonText type="normalInfo">{bucketName}</CommonText>
-            <CommonText type="normalInfo">{bucketBudget}원</CommonText>
+            <CommonText type="normalInfo">버킷 총액: {formatNumber(totalPrice)}원</CommonText>
+            {bucketBudget && (
+              <CommonText type="normalInfo">예산: {formatNumber(bucketBudget)}원</CommonText>
+            )}
           </BucketInfoBox>
         )}
         <ImageBox onClick={() => onClick(feedId)}>

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -56,7 +56,7 @@ const FeedDetail = () => {
             createdAt={feedDetail.data.feedInfo.createdAt}
             feedItems={feedDetail.data.feedItems}
             bucketName={feedDetail.data.feedInfo.bucketName}
-            bucketBudget={feedDetail.data.feedInfo.bucketBudget}
+            totalPrice={feedDetail.data.feedInfo.totalPrice}
             isDetail
             onClick={onOpen}
           />

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -25,6 +25,8 @@ import {
   ContentsPanel,
   SubTitleBox,
   ImagePanel,
+  NoResult,
+  Grid,
 } from './style';
 import { useLeave, useLogout } from '@/features/member/hooks';
 import { memberQueryOption } from '@/features/member/service';
@@ -86,15 +88,27 @@ const MemberHome = () => {
                 <CommonText type="smallTitle">인벤토리</CommonText>
               </SubTitleBox>
               <CommonText type="smallInfo">
-                취미별 아이템을 조합하여 나만의 인벤토리을 만들 수 있어요
+                취미별 아이템을 조합하여 나만의 인벤토리를 만들 수 있어요
               </CommonText>
             </div>
-            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+            <CommonIconButton
+              type="detail"
+              fontSize="0.8rem"
+              onClick={() => navigate(`/member/${nickname}/inventory`)}
+            />
           </ContentsPanel>
           <ImagePanel>
-            <DividerImage type="base" images={['1', '2', '3']} />
-            <DividerImage type="base" images={['1', '2', '3']} />
-            <DividerImage type="base" images={['1', '2', '3']} />
+            {member.isSuccess && member.data.inventoryProfiles.length > 0 ? (
+              <Grid>
+                {member.data.inventoryProfiles.map((inventory) => (
+                  <DividerImage key={inventory.id} type="base" images={inventory.images} />
+                ))}
+              </Grid>
+            ) : (
+              <NoResult>
+                <CommonText type="normalInfo">인벤토리가 존재하지 않습니다.</CommonText>
+              </NoResult>
+            )}
           </ImagePanel>
         </ContentsWrapper>
         <CommonDivider size="sm" />
@@ -109,12 +123,24 @@ const MemberHome = () => {
                 취미별 아이템을 조합하여 나만의 버킷을 만들 수 있어요
               </CommonText>
             </div>
-            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+            <CommonIconButton
+              type="detail"
+              fontSize="0.8rem"
+              onClick={() => navigate(`/member/${nickname}/bucket`)}
+            />
           </ContentsPanel>
           <ImagePanel>
-            <DividerImage type="base" images={['1', '2', '3']} />
-            <DividerImage type="base" images={['1', '2', '3']} />
-            <DividerImage type="base" images={['1', '2', '3']} />
+            {member.isSuccess && member.data.bucketProfiles.length > 0 ? (
+              <Grid>
+                {member.data?.bucketProfiles.map((bucket) => (
+                  <DividerImage key={bucket.id} type="base" images={bucket.images} />
+                ))}
+              </Grid>
+            ) : (
+              <NoResult>
+                <CommonText type="normalInfo">버킷이 존재하지 않습니다.</CommonText>
+              </NoResult>
+            )}
           </ImagePanel>
         </ContentsWrapper>
         <CommonDivider size="sm" />
@@ -129,7 +155,11 @@ const MemberHome = () => {
                 내가 올린 피드와 좋아요한 피드를 확인할 수 있어요
               </CommonText>
             </div>
-            <CommonIconButton type="detail" fontSize="0.8rem" onClick={() => {}} />
+            <CommonIconButton
+              type="detail"
+              fontSize="0.8rem"
+              onClick={() => navigate(`/member/${nickname}/feed`)}
+            />
           </ContentsPanel>
         </ContentsWrapper>
         <CommonDivider size="sm" />

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -25,7 +25,6 @@ import {
   ContentsPanel,
   SubTitleBox,
   ImagePanel,
-  NoResult,
   Grid,
 } from './style';
 import { useLeave, useLogout } from '@/features/member/hooks';
@@ -97,19 +96,15 @@ const MemberHome = () => {
               onClick={() => navigate(`/member/${nickname}/inventory`)}
             />
           </ContentsPanel>
-          <ImagePanel>
-            {member.isSuccess && member.data.inventoryProfiles.length > 0 ? (
+          {member.isSuccess && member.data.inventoryProfiles.length > 0 && (
+            <ImagePanel>
               <Grid>
                 {member.data.inventoryProfiles.map((inventory) => (
                   <DividerImage key={inventory.id} type="base" images={inventory.images} />
                 ))}
               </Grid>
-            ) : (
-              <NoResult>
-                <CommonText type="normalInfo">인벤토리가 존재하지 않습니다.</CommonText>
-              </NoResult>
-            )}
-          </ImagePanel>
+            </ImagePanel>
+          )}
         </ContentsWrapper>
         <CommonDivider size="sm" />
         <ContentsWrapper>
@@ -129,19 +124,15 @@ const MemberHome = () => {
               onClick={() => navigate(`/member/${nickname}/bucket`)}
             />
           </ContentsPanel>
-          <ImagePanel>
-            {member.isSuccess && member.data.bucketProfiles.length > 0 ? (
+          {member.isSuccess && member.data.bucketProfiles.length > 0 && (
+            <ImagePanel>
               <Grid>
                 {member.data?.bucketProfiles.map((bucket) => (
                   <DividerImage key={bucket.id} type="base" images={bucket.images} />
                 ))}
               </Grid>
-            ) : (
-              <NoResult>
-                <CommonText type="normalInfo">버킷이 존재하지 않습니다.</CommonText>
-              </NoResult>
-            )}
-          </ImagePanel>
+            </ImagePanel>
+          )}
         </ContentsWrapper>
         <CommonDivider size="sm" />
         <ContentsWrapper>

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -27,8 +27,7 @@ export const MemberInfoBox = styled.div`
 
 export const MemberIntroWrapper = styled.div`
   display: flex;
-  justify-content: center;
-  padding: 1.5rem 3rem;
+  padding: 1.5rem 3.5rem;
 `;
 
 export const ContentsWrapper = styled.div`
@@ -52,4 +51,16 @@ export const ImagePanel = styled.div`
   display: flex;
   gap: 1rem;
   padding-top: 1rem;
+`;
+
+export const NoResult = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
 `;

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -53,12 +53,6 @@ export const ImagePanel = styled.div`
   padding-top: 1rem;
 `;
 
-export const NoResult = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-`;
-
 export const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -5,7 +5,7 @@ interface DividerImageProps {
   type: 'base' | 'live';
 }
 
-const BORDER_TYPE = '1px solid black';
+const BORDER_TYPE = '1px solid #E2E8F0';
 const GRID_REPEAT = 'repeat(2, 1fr)';
 
 const isFirstAndThird = (index: number) => index === 1 || index === 3;
@@ -50,6 +50,8 @@ const DividerImage = ({ images, type }: DividerImageProps) => {
         borderRadius="0.625rem"
         background="linear-gradient(90deg, #DCE1E8 0%, #EDF2F7 100%);"
         overflow="hidden"
+        borderWidth="1px"
+        borderColor="gray.200"
       >
         {images.map((image, index) => {
           return (

--- a/src/shared/types/feed.ts
+++ b/src/shared/types/feed.ts
@@ -28,6 +28,7 @@ export interface FeedInfo {
   hasAdoptedComment: boolean;
   likeCount: number;
   isLiked: boolean;
+  totalPrice: number;
 }
 
 export interface FeedItemInfo {


### PR DESCRIPTION
## 구현(수정) 내용
멤버 페이지의 인벤토리, 버킷 데이터를 연결했습니다.
피드 상세 페이지의 버킷 총액을 추가했습니다.
DividerImage 컴포넌트의 디자인을 수정했습니다.

## 스크린샷
<img width="348" alt="스크린샷 2023-11-23 오후 6 48 00" src="https://github.com/bucket-back/bucket-back-frontend/assets/40534414/60eb0a9f-61db-4a3b-86cf-a929c616d504">

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
