### PR TITLE
[OMCT-330] 피드 수정 페이지 UI 구현 및 HobbyRadio 컴포넌트 추가

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -24,6 +24,7 @@ import {
   InventoryCreate,
   SearchMain,
   SearchHome,
+  FeedUpdate,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -59,7 +60,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'feed/:feedId/edit',
-        element: <div>feed feedId edit</div>,
+        element: <FeedUpdate />,
       },
       {
         path: 'vote/create',

--- a/src/features/hobby/components/HobbyRadio/index.tsx
+++ b/src/features/hobby/components/HobbyRadio/index.tsx
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { CommonRadio } from '@/shared/components';
+import { hobbyQueryOption } from '../../service';
+import { Container } from './style';
+
+interface HobbyRadioProps {
+  defaultValue?: string;
+  onChange?: React.Dispatch<React.SetStateAction<string>>;
+  isReadOnly?: boolean;
+}
+
+const HobbyRadio = ({ defaultValue, onChange, isReadOnly }: HobbyRadioProps) => {
+  const { data, isPending, isError } = useQuery({
+    ...hobbyQueryOption.all(),
+    select: (data) =>
+      data.hobbies.reduce<Record<string, string>>(
+        (acc, cur) => ((acc[cur.value] = cur.name), acc),
+        {}
+      ),
+  });
+
+  if (isPending) {
+    return;
+  }
+
+  if (isError) {
+    return;
+  }
+
+  const hangulHobby = Object.keys(data);
+
+  const handleChange = (value: string) => {
+    onChange && onChange(value);
+  };
+
+  return (
+    <Container>
+      <CommonRadio
+        values={hangulHobby}
+        name="취미"
+        onChange={(value: string) => handleChange(data[value])}
+        defaultValue={defaultValue}
+        isReadOnly={isReadOnly}
+      />
+    </Container>
+  );
+};
+
+export default HobbyRadio;

--- a/src/features/hobby/components/HobbyRadio/style.ts
+++ b/src/features/hobby/components/HobbyRadio/style.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  overflow-x: auto;
+`;

--- a/src/features/hobby/components/index.ts
+++ b/src/features/hobby/components/index.ts
@@ -1,0 +1,1 @@
+export { default as HobbyRadio } from './HobbyRadio';

--- a/src/pages/Feed/FeedCreate/index.tsx
+++ b/src/pages/Feed/FeedCreate/index.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import {
   CommonButton,
   CommonDrawer,
-  CommonRadio,
   CommonText,
   CommonTextarea,
   DividerImage,
@@ -15,7 +14,6 @@ import {
   Container,
   ContentsWrapper,
   ContentsPanel,
-  HobbyBox,
   Form,
   ButtonWrapper,
   SelectedBucketBox,
@@ -23,7 +21,7 @@ import {
 import { bucketQueryOption } from '@/features/bucket/service';
 import { FeedSelectBucket } from '@/features/feed/components';
 import { useCreateFeed } from '@/features/feed/hooks';
-import { useHobby } from '@/features/hobby/hooks';
+import { HobbyRadio } from '@/features/hobby/components';
 
 interface SelectedBucket {
   id: number;
@@ -56,14 +54,6 @@ const FeedCreate = () => {
   };
   const { isOpen, onOpen, onClose } = useDrawer();
 
-  const hobby = useHobby();
-  const hobbyObj = hobby.data?.hobbies.reduce<Record<string, string>>(
-    (acc, cur) => ((acc[cur.value] = cur.name), acc),
-    {}
-  );
-
-  const hobbyValues = Object.keys(hobbyObj || {});
-
   return (
     <>
       <Header type="back" />
@@ -73,15 +63,7 @@ const FeedCreate = () => {
           <ContentsWrapper>
             <ContentsPanel>
               <CommonText type="normalInfo">취미를 선택해주세요.</CommonText>
-              <HobbyBox>
-                {hobbyObj && (
-                  <CommonRadio
-                    values={hobbyValues}
-                    name="취미"
-                    onChange={(value: string) => setSelectedHobby(hobbyObj[value])}
-                  />
-                )}
-              </HobbyBox>
+              <HobbyRadio onChange={setSelectedHobby} />
             </ContentsPanel>
             <ContentsPanel>
               <CommonText type="normalInfo">버킷을 선택해주세요.</CommonText>
@@ -100,7 +82,6 @@ const FeedCreate = () => {
             </ContentsPanel>
             <ContentsPanel>
               <CommonText type="normalInfo">피드 내용을 입력해주세요.</CommonText>
-
               <CommonTextarea
                 size="sm"
                 placeholder="내용을 입력해주세요."
@@ -121,7 +102,6 @@ const FeedCreate = () => {
             </CommonButton>
           </ButtonWrapper>
         </Form>
-
         <CommonDrawer
           isOpen={isOpen}
           onClose={onClose}

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   CommonButton,
@@ -33,6 +33,7 @@ const FeedDetail = () => {
   const isLogin = useAuthCheck();
   const userInfo = useUserInfo();
   const deleteFeed = useDeleteFeed();
+  const navigate = useNavigate();
 
   const feedDetail = useQuery(feedQueryOption.detail(feedIdNumber));
   const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber || 1, size: 10 }));
@@ -63,6 +64,7 @@ const FeedDetail = () => {
             isDetail
             onClick={onOpen}
             onDelete={onDeleteOpen}
+            onUpdate={() => navigate(`./edit`)}
           />
         )}
       </FeedDetailContainer>

--- a/src/pages/Feed/FeedUpdate/index.tsx
+++ b/src/pages/Feed/FeedUpdate/index.tsx
@@ -1,0 +1,52 @@
+import {
+  CommonButton,
+  CommonText,
+  CommonTextarea,
+  DividerImage,
+  Header,
+} from '@/shared/components';
+import {
+  ButtonWrapper,
+  Container,
+  ContentsPanel,
+  ContentsWrapper,
+  Form,
+  SelectedBucketBox,
+} from './style';
+import { HobbyRadio } from '@/features/hobby/components';
+
+const FeedUpdate = () => {
+  return (
+    <>
+      <Header type="back" />
+      <Container>
+        <CommonText type="normalTitle">피드 수정하기</CommonText>
+        <Form>
+          <ContentsWrapper>
+            <ContentsPanel>
+              <CommonText type="normalInfo">취미를 선택해주세요.</CommonText>
+              <HobbyRadio defaultValue="야구" isReadOnly />
+            </ContentsPanel>
+            <ContentsPanel>
+              <CommonText type="normalInfo">버킷을 선택해주세요.</CommonText>
+              <SelectedBucketBox>
+                <DividerImage images={['1', '2', '3']} type="base" />
+              </SelectedBucketBox>
+            </ContentsPanel>
+            <ContentsPanel>
+              <CommonText type="normalInfo">피드 내용을 입력해주세요.</CommonText>
+              <CommonTextarea size="sm" placeholder="내용을 입력해주세요." />
+            </ContentsPanel>
+          </ContentsWrapper>
+          <ButtonWrapper>
+            <CommonButton type="mdFull" isSubmit>
+              수정 완료
+            </CommonButton>
+          </ButtonWrapper>
+        </Form>
+      </Container>
+    </>
+  );
+};
+
+export default FeedUpdate;

--- a/src/pages/Feed/FeedUpdate/style.ts
+++ b/src/pages/Feed/FeedUpdate/style.ts
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 2.44rem 2.44rem 2.44rem;
+  gap: 1.5rem;
+`;
+
+export const Form = styled.form`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export const ContentsPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const SelectedBucketBox = styled.div`
+  width: 6.125rem;
+  height: 5.625rem;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -21,3 +21,4 @@ export { default as InventoryDetail } from './Inventory/InventoryDetail';
 export { default as InventoryHome } from './Inventory/InventoryHome';
 export { default as SearchHome } from './Search/SearchHome';
 export { default as SearchMain } from './Search/SearchMain';
+export { default as FeedUpdate } from './Feed/FeedUpdate';

--- a/src/shared/components/Radio/index.tsx
+++ b/src/shared/components/Radio/index.tsx
@@ -14,9 +14,16 @@ interface CommonRadioProps {
   name: string;
   defaultValue?: string;
   onChange: (value: string) => void;
+  isReadOnly?: boolean;
 }
 
-const CommonRadio = ({ values, defaultValue, name, onChange }: CommonRadioProps) => {
+const CommonRadio = ({
+  values,
+  defaultValue,
+  name,
+  onChange,
+  isReadOnly = false,
+}: CommonRadioProps) => {
   const options = [...values];
 
   const { getRootProps, getRadioProps } = useRadioGroup({
@@ -34,7 +41,9 @@ const CommonRadio = ({ values, defaultValue, name, onChange }: CommonRadioProps)
 
         return (
           <HobbyBox key={value}>
-            <RadioCard {...radio}>{value}</RadioCard>
+            <RadioCard {...radio} isReadOnly={isReadOnly}>
+              {value}
+            </RadioCard>
           </HobbyBox>
         );
       })}


### PR DESCRIPTION
## 구현(수정) 내용
피드 수정 페이지 UI를 구현했습니다.
추가로 취미를 선택하는 라디오부분을 컴포넌트로 분리하여 HobbyRadio 컴포넌트로 만들었습니다.
피드를 수정시에는 취미를 변경할 수 없기때문에 isReadOnly라는 prop을 CommonRadio 컴포넌트에 추가했습니다.

## 스크린샷
![스크린샷 2023-11-25 오전 1 21 16](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/01ce27b4-a8d5-4d64-b9e5-6116124a19f8)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
