### PR TITLE
[OMCT-338] 댓글 채택 및 수정 api 연결

### DIFF
--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { CommonButton, CommonMenu, CommonText, DateText, Profile } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
 import { MemberInfo } from '@/shared/types';
@@ -31,6 +32,7 @@ const CommentItem = ({
 }: CommentItemProps) => {
   const userInfo = useUserInfo();
   const adoptComment = useAdoptComment();
+  const navigate = useNavigate();
 
   return (
     <Container>
@@ -51,7 +53,12 @@ const CommentItem = ({
       <ContentsWrapper>
         <DateText createdDate={createdAt} />
         <InteractPanel>
-          <CommonButton type="xsText">인벤토리</CommonButton>
+          <CommonButton
+            type="xsText"
+            onClick={() => navigate(`/member/${memberInfo.nickName}/inventory`)}
+          >
+            인벤토리
+          </CommonButton>
           {isOwnFeed && !hasAdoptedComment && (
             <CommonButton type="xsText" onClick={() => adoptComment.mutate({ feedId, commentId })}>
               채택하기

--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -1,7 +1,7 @@
 import { CommonButton, CommonMenu, CommonText, DateText, Profile } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
 import { MemberInfo } from '@/shared/types';
-import { useAdoptComment, useDeleteComment } from '../../hooks';
+import { useAdoptComment } from '../../hooks';
 import { Container, ProfileWrapper, ContentsWrapper, InteractPanel } from './style';
 
 interface CommentItemProps {
@@ -13,6 +13,7 @@ interface CommentItemProps {
   memberInfo: MemberInfo;
   isOwnFeed: boolean;
   hasAdoptedComment: boolean;
+  onDelete: () => void;
   onUpdate: () => void;
 }
 
@@ -25,10 +26,10 @@ const CommentItem = ({
   memberInfo,
   isOwnFeed,
   hasAdoptedComment,
+  onDelete,
   onUpdate,
 }: CommentItemProps) => {
   const userInfo = useUserInfo();
-  const deletComment = useDeleteComment();
   const adoptComment = useAdoptComment();
 
   return (
@@ -41,14 +42,7 @@ const CommentItem = ({
           isAdopted={isAdopted}
         />
         {userInfo?.nickname === memberInfo.nickName && (
-          <CommonMenu
-            type="update"
-            iconSize="0.25rem"
-            onDelete={() => {
-              deletComment.mutate({ feedId, commentId });
-            }}
-            onUpdate={onUpdate}
-          />
+          <CommonMenu type="update" iconSize="0.25rem" onDelete={onDelete} onUpdate={onUpdate} />
         )}
       </ProfileWrapper>
       <ContentsWrapper>

--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -1,7 +1,7 @@
 import { CommonButton, CommonMenu, CommonText, DateText, Profile } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
 import { MemberInfo } from '@/shared/types';
-import { useDeleteComment } from '../../hooks';
+import { useAdoptComment, useDeleteComment } from '../../hooks';
 import { Container, ProfileWrapper, ContentsWrapper, InteractPanel } from './style';
 
 interface CommentItemProps {
@@ -27,6 +27,7 @@ const CommentItem = ({
 }: CommentItemProps) => {
   const userInfo = useUserInfo();
   const deletComment = useDeleteComment();
+  const adoptComment = useAdoptComment();
 
   return (
     <Container>
@@ -55,7 +56,11 @@ const CommentItem = ({
         <DateText createdDate={createdAt} />
         <InteractPanel>
           <CommonButton type="xsText">인벤토리</CommonButton>
-          {isOwnFeed && !hasAdoptedComment && <CommonButton type="xsText">채택하기</CommonButton>}
+          {isOwnFeed && !hasAdoptedComment && (
+            <CommonButton type="xsText" onClick={() => adoptComment.mutate({ feedId, commentId })}>
+              채택하기
+            </CommonButton>
+          )}
         </InteractPanel>
       </ContentsWrapper>
     </Container>

--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -13,6 +13,7 @@ interface CommentItemProps {
   memberInfo: MemberInfo;
   isOwnFeed: boolean;
   hasAdoptedComment: boolean;
+  onUpdate: () => void;
 }
 
 const CommentItem = ({
@@ -24,6 +25,7 @@ const CommentItem = ({
   memberInfo,
   isOwnFeed,
   hasAdoptedComment,
+  onUpdate,
 }: CommentItemProps) => {
   const userInfo = useUserInfo();
   const deletComment = useDeleteComment();
@@ -45,7 +47,7 @@ const CommentItem = ({
             onDelete={() => {
               deletComment.mutate({ feedId, commentId });
             }}
-            onUpdate={() => {}}
+            onUpdate={onUpdate}
           />
         )}
       </ProfileWrapper>

--- a/src/features/comment/hooks/index.ts
+++ b/src/features/comment/hooks/index.ts
@@ -1,2 +1,4 @@
 export { default as useAddComment } from './useAddComment';
 export { default as useDeleteComment } from './useDeleteComment';
+export { default as useAdoptComment } from './useAdoptComment';
+export { default as useUpdateComment } from './useUpdateComment';

--- a/src/features/comment/hooks/useAddComment.ts
+++ b/src/features/comment/hooks/useAddComment.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
 
 const useAddComment = () => {
   const queryClient = useQueryClient();
+  const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: commentApi.postComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      openToast({ message: '댓글이 추가되었습니다.', type: 'success' });
     },
   });
 };

--- a/src/features/comment/hooks/useAdoptComment.ts
+++ b/src/features/comment/hooks/useAdoptComment.ts
@@ -1,15 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
 import { feedQueryOption } from '@/features/feed/service';
 
 const useAdoptComment = () => {
   const queryClient = useQueryClient();
+  const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: commentApi.postCommentAdoption,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
       queryClient.invalidateQueries({ queryKey: feedQueryOption.all });
+      openToast({ message: '댓글을 채택했습니다.', type: 'success' });
     },
   });
 };

--- a/src/features/comment/hooks/useAdoptComment.ts
+++ b/src/features/comment/hooks/useAdoptComment.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { commentApi, commentQueryQption } from '../service';
+import { feedQueryOption } from '@/features/feed/service';
+
+const useAdoptComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: commentApi.postCommentAdoption,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      queryClient.invalidateQueries({ queryKey: feedQueryOption.all });
+    },
+  });
+};
+
+export default useAdoptComment;

--- a/src/features/comment/hooks/useDeleteComment.ts
+++ b/src/features/comment/hooks/useDeleteComment.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
 
 const useDeleteComment = () => {
   const queryClient = useQueryClient();
+  const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: commentApi.deleteComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      openToast({ message: '댓글이 삭제되었습니다.', type: 'success' });
     },
   });
 };

--- a/src/features/comment/hooks/useUpdateComment.ts
+++ b/src/features/comment/hooks/useUpdateComment.ts
@@ -2,14 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
 
-const useUpdateComment = () => {
+const useUpdateComment = (feedId: number) => {
   const queryClient = useQueryClient();
   const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: commentApi.putComment,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      queryClient.invalidateQueries({ queryKey: [...commentQueryQption.all, feedId] });
       openToast({ message: '댓글이 수정되었습니다.', type: 'success' });
     },
   });

--- a/src/features/comment/hooks/useUpdateComment.ts
+++ b/src/features/comment/hooks/useUpdateComment.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
 
 const useUpdateComment = () => {
   const queryClient = useQueryClient();
+  const openToast = useCustomToast();
 
   return useMutation({
     mutationFn: commentApi.putComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      openToast({ message: '댓글이 수정되었습니다.', type: 'success' });
     },
   });
 };

--- a/src/features/comment/hooks/useUpdateComment.ts
+++ b/src/features/comment/hooks/useUpdateComment.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { commentApi, commentQueryQption } from '../service';
+
+const useUpdateComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: commentApi.putComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+    },
+  });
+};
+
+export default useUpdateComment;

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -43,7 +43,7 @@ const FeedDetail = () => {
 
   const feedDetail = useQuery(feedQueryOption.detail(feedIdNumber));
   const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber || 1, size: 10 }));
-  const { register, handleSubmit, reset } = useForm<CommentContent>();
+  const { register, handleSubmit, reset, setValue } = useForm<CommentContent>();
   const addComment = useAddComment();
   const onCreateComment: SubmitHandler<CommentContent> = (data) => {
     addComment.mutate({ feedId: feedIdNumber, content: data.content });
@@ -63,6 +63,7 @@ const FeedDetail = () => {
       commentId: updatingCommentId,
       content: data.content,
     });
+    setIsUpdating(false);
     reset();
   };
 
@@ -99,7 +100,7 @@ const FeedDetail = () => {
         </CommentNumberWrapper>
         <CommonDivider size="sm" />
       </div>
-      <CommentsContainer>
+      <CommentsContainer style={{ filter: isUpdating ? 'blur(2px)' : undefined }}>
         {comment.isSuccess && comment.data.totalCount > 0 ? (
           comment.data.comments.map((data) => (
             <Fragment key={data.commentId}>
@@ -118,6 +119,7 @@ const FeedDetail = () => {
                   onDeleteOpen();
                 }}
                 onUpdate={() => {
+                  setValue('content', data.content);
                   setIsUpdating(true);
                   setUpdatingCommentId(data.commentId);
                 }}
@@ -137,7 +139,7 @@ const FeedDetail = () => {
             width="100%"
             placeholder="댓글을 수정해주세요"
             rightIcon={
-              <CommonButton type="mdFull" isSubmit isDisabled={!isLogin}>
+              <CommonButton type="mdFull" isSubmit>
                 수정
               </CommonButton>
             }

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -54,7 +54,7 @@ const FeedDetail = () => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [updatingCommentId, setUpdatingCommentId] = useState(0);
   const [selectedCommentId, setSelectedCommentId] = useState(0);
-  const updateComment = useUpdateComment();
+  const updateComment = useUpdateComment(feedIdNumber);
   const deleteComment = useDeleteComment();
 
   const onUpdateComment: SubmitHandler<CommentContent> = (data) => {


### PR DESCRIPTION
## 구현(수정) 내용
댓글 채택 및 수정 api를 연결했습니다.
댓글 관련 기능에서 성공시 나오는 토스트가 없었어서 추가했습니다.
댓글 삭제시 drawer가 나오도록 추가했습니다.

## 스크린샷
![스크린샷 2023-11-25 오후 4 44 50](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/06b60ec5-d54e-416e-a116-5aba6fa54a61)

![스크린샷 2023-11-25 오후 4 43 49](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/88c922b7-a264-4621-8e2a-eeb72be3b0f5)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
