### PR TITLE
[OMCT-341] 버킷 목록, 상세 페이지 UI 구현

### DIFF
--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -25,6 +25,7 @@ import {
   SearchMain,
   SearchHome,
   FeedUpdate,
+  BucketHome,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -124,7 +125,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'member/:nickname/bucket',
-        element: <div>member nickname bucket</div>,
+        element: <BucketHome />,
       },
       {
         path: 'member/:nickname/bucket/:bucketId',

--- a/src/core/routes/router.tsx
+++ b/src/core/routes/router.tsx
@@ -26,6 +26,7 @@ import {
   SearchHome,
   FeedUpdate,
   BucketHome,
+  BucketDetail,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -129,7 +130,7 @@ export const router = createBrowserRouter([
       },
       {
         path: 'member/:nickname/bucket/:bucketId',
-        element: <div>member nickname bucket bucketId</div>,
+        element: <BucketDetail />,
       },
       {
         path: 'bucket/create',

--- a/src/pages/Bucket/BucketDetail/index.tsx
+++ b/src/pages/Bucket/BucketDetail/index.tsx
@@ -1,0 +1,39 @@
+import { CommonIconButton, CommonImage, CommonText, Header } from '@/shared/components';
+import { Container, ContentsBox, ContentsWrapper, TitlePanel, TitleWrapper } from './style';
+
+const BucketDetail = () => {
+  return (
+    <>
+      <Header type="back" />
+      <Container>
+        <TitleWrapper>
+          <TitlePanel>
+            <CommonText type="normalTitle">버킷 이름</CommonText>
+            <CommonText type="normalTitle">아이템 전체보기</CommonText>
+            <CommonText type="subStrongInfo">총 0개의 아이템</CommonText>
+          </TitlePanel>
+          <CommonIconButton type="update" onClick={() => {}} />
+        </TitleWrapper>
+        <ContentsWrapper>
+          <ContentsBox>
+            <CommonImage size="sm" src="1" />
+            <CommonText type="smallInfo">아이템명</CommonText>
+            <CommonText type="smallInfo">10000원</CommonText>
+          </ContentsBox>
+          <ContentsBox>
+            <CommonImage size="sm" src="1" />
+            <CommonText type="smallInfo">아이템명</CommonText>
+            <CommonText type="smallInfo">10000원</CommonText>
+          </ContentsBox>
+          <ContentsBox>
+            <CommonImage size="sm" src="1" />
+            <CommonText type="smallInfo">아이템명</CommonText>
+            <CommonText type="smallInfo">10000원</CommonText>
+          </ContentsBox>
+        </ContentsWrapper>
+      </Container>
+    </>
+  );
+};
+
+export default BucketDetail;

--- a/src/pages/Bucket/BucketDetail/style.ts
+++ b/src/pages/Bucket/BucketDetail/style.ts
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2rem 1rem 2.44rem;
+`;
+
+export const TitlePanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  padding: 0 2.44rem 1rem 2.44rem;
+`;
+
+export const ContentsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+`;

--- a/src/pages/Bucket/BucketHome/index.tsx
+++ b/src/pages/Bucket/BucketHome/index.tsx
@@ -22,6 +22,7 @@ const BucketHome = () => {
         </TitleWrapper>
         <CommonDivider size="sm" />
         <CommonTabs
+          paddingLeftRight={2}
           tabsType="soft-rounded"
           isFitted={false}
           tabsData={[

--- a/src/pages/Bucket/BucketHome/index.tsx
+++ b/src/pages/Bucket/BucketHome/index.tsx
@@ -1,0 +1,63 @@
+import {
+  CommonDivider,
+  CommonMenu,
+  CommonTabs,
+  CommonText,
+  DividerImage,
+  Header,
+} from '@/shared/components';
+import { Container, ContentsBox, ContentsWrapper, TitlePanel, TitleWrapper } from './style';
+
+const BucketHome = () => {
+  return (
+    <>
+      <Header type="back" />
+      <Container>
+        <TitleWrapper>
+          <TitlePanel>
+            <CommonText type="normalTitle">버킷</CommonText>
+            <CommonText type="subStrongInfo">총 0개의 버킷</CommonText>
+          </TitlePanel>
+          <CommonMenu type="create" iconSize="0.35rem" onDelete={() => {}} />
+        </TitleWrapper>
+        <CommonDivider size="sm" />
+        <CommonTabs
+          tabsType="soft-rounded"
+          isFitted={false}
+          tabsData={[
+            {
+              value: 'cycle',
+              label: '자전거',
+              content: (
+                <ContentsWrapper>
+                  <ContentsBox>
+                    <DividerImage type="base" images={['1', '2', '3']} />
+                    <CommonText type="smallInfo">버킷명</CommonText>
+                    <CommonText type="smallInfo">10000원</CommonText>
+                  </ContentsBox>
+                  <ContentsBox>
+                    <DividerImage type="base" images={['1', '2', '3']} />
+                    <CommonText type="smallInfo">버킷명</CommonText>
+                    <CommonText type="smallInfo">10000원</CommonText>
+                  </ContentsBox>
+                  <ContentsBox>
+                    <DividerImage type="base" images={['1', '2', '3']} />
+                    <CommonText type="smallInfo">버킷명</CommonText>
+                    <CommonText type="smallInfo">10000원</CommonText>
+                  </ContentsBox>
+                  <ContentsBox>
+                    <DividerImage type="base" images={['1', '2', '3']} />
+                    <CommonText type="smallInfo">버킷명</CommonText>
+                    <CommonText type="smallInfo">10000원</CommonText>
+                  </ContentsBox>
+                </ContentsWrapper>
+              ),
+            },
+          ]}
+        />
+      </Container>
+    </>
+  );
+};
+
+export default BucketHome;

--- a/src/pages/Bucket/BucketHome/style.ts
+++ b/src/pages/Bucket/BucketHome/style.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2rem 1rem 2.44rem;
+`;
+
+export const TitlePanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  padding: 1rem 1rem 0 1rem;
+`;
+
+export const ContentsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+`;

--- a/src/pages/Bucket/BucketHome/style.ts
+++ b/src/pages/Bucket/BucketHome/style.ts
@@ -23,7 +23,7 @@ export const ContentsWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 0.5rem;
-  padding: 1rem 1rem 0 1rem;
+  padding: 1rem 2rem 0 2rem;
 `;
 
 export const ContentsBox = styled.div`

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -23,3 +23,4 @@ export { default as SearchHome } from './Search/SearchHome';
 export { default as SearchMain } from './Search/SearchMain';
 export { default as FeedUpdate } from './Feed/FeedUpdate';
 export { default as BucketHome } from './Bucket/BucketHome';
+export { default as BucketDetail } from './Bucket/BucketDetail';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -22,3 +22,4 @@ export { default as InventoryHome } from './Inventory/InventoryHome';
 export { default as SearchHome } from './Search/SearchHome';
 export { default as SearchMain } from './Search/SearchMain';
 export { default as FeedUpdate } from './Feed/FeedUpdate';
+export { default as BucketHome } from './Bucket/BucketHome';

--- a/src/shared/components/Tabs/index.tsx
+++ b/src/shared/components/Tabs/index.tsx
@@ -12,6 +12,7 @@ interface CommonTabsProps {
   tabsData: TabsData[];
   onClick?: (value: string) => void;
   currentTabIndex?: number;
+  paddingLeftRight?: number;
 }
 
 const selectedStyle = (tabsType: string) => {
@@ -26,6 +27,7 @@ const CommonTabs = ({
   tabsType = 'line',
   onClick,
   currentTabIndex = 0,
+  paddingLeftRight = 1,
 }: CommonTabsProps) => {
   const handleClick = (value: string) => {
     onClick && onClick(value);
@@ -34,7 +36,11 @@ const CommonTabs = ({
   return (
     <Tabs index={currentTabIndex} isFitted={isFitted} variant={tabsType} size="sm">
       <TabList
-        padding={tabsType === 'soft-rounded' ? '1rem 0 0 1rem' : undefined}
+        padding={
+          tabsType === 'soft-rounded'
+            ? `1rem ${paddingLeftRight}rem 0 ${paddingLeftRight}rem`
+            : undefined
+        }
         overflowY={tabsType === 'soft-rounded' ? 'hidden' : undefined}
         overflowX={tabsType === 'soft-rounded' ? 'auto' : undefined}
       >

--- a/src/shared/components/Tabs/index.tsx
+++ b/src/shared/components/Tabs/index.tsx
@@ -33,12 +33,17 @@ const CommonTabs = ({
 
   return (
     <Tabs index={currentTabIndex} isFitted={isFitted} variant={tabsType} size="sm">
-      <TabList padding={tabsType === 'soft-rounded' ? '1rem 0 0 1rem' : undefined}>
+      <TabList
+        padding={tabsType === 'soft-rounded' ? '1rem 0 0 1rem' : undefined}
+        overflowY={tabsType === 'soft-rounded' ? 'hidden' : undefined}
+        overflowX={tabsType === 'soft-rounded' ? 'auto' : undefined}
+      >
         {tabsData.map((tab, index) => (
           <Tab
             onClick={() => handleClick(tab.value ?? '')}
             color="blue.900"
             bg="none"
+            flexShrink={0}
             _selected={selectedStyle(tabsType)}
             _disabled={selectedStyle(tabsType)}
             isDisabled={currentTabIndex === index}


### PR DESCRIPTION
## 구현(수정) 내용
버킷 목록, 상세 페이지의 UI를 구현했습니다.
취미에 사용되는 Tab의 스타일을 수정했습니다.

## 스크린샷
![스크린샷 2023-11-25 오후 10 00 31](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/defc85bb-9879-49cc-81b6-8935b62d274d)
![스크린샷 2023-11-25 오후 10 00 49](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/90647274-7e37-44c5-84b0-eed4fc524090)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
