### PR TITLE
[OMCT-348] 프로필 이미지 수정 기능 추가

### DIFF
--- a/src/features/member/components/MemberEditForm/index.tsx
+++ b/src/features/member/components/MemberEditForm/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/shared/components';
 import { useValidateForm } from '@/shared/hooks';
 import useUpdateImage from '../../hooks/useUpdateImage';
-import { AvatarBox, ButtonWrapper, Form, InputBox, InputWrapper } from './style';
+import { AvatarBox, ButtonWrapper, FileInput, Form, InputBox, InputWrapper } from './style';
 import { useCheckNickname, useUpateMemberInfo } from '@/features/member/hooks';
 
 interface MemberEditFormProps {
@@ -66,9 +66,11 @@ const MemberEditForm = ({ nickname, image, introduction }: MemberEditFormProps) 
       <InputWrapper>
         <div>
           <CommonText type="strongInfo">프로필 사진</CommonText>
-          <input type="file" {...register('image')} />
+
           <AvatarBox>
-            <CommonAvatar src={imagePreview || image || ''} isOwner />
+            <CommonAvatar src={imagePreview || image || ''} isOwner>
+              <FileInput type="file" {...register('image')} />
+            </CommonAvatar>
           </AvatarBox>
         </div>
         <div>

--- a/src/features/member/components/MemberEditForm/index.tsx
+++ b/src/features/member/components/MemberEditForm/index.tsx
@@ -29,7 +29,7 @@ const MemberEditForm = ({ nickname, image, introduction }: MemberEditFormProps) 
   } = useForm<MemberEditFormProps>({
     mode: 'onBlur',
     defaultValues: {
-      image,
+      image: '',
       nickname,
       introduction,
     },
@@ -68,7 +68,7 @@ const MemberEditForm = ({ nickname, image, introduction }: MemberEditFormProps) 
           <CommonText type="strongInfo">프로필 사진</CommonText>
           <input type="file" {...register('image')} />
           <AvatarBox>
-            <CommonAvatar src={imagePreview || image} isOwner />
+            <CommonAvatar src={imagePreview || image || ''} isOwner />
           </AvatarBox>
         </div>
         <div>

--- a/src/features/member/components/MemberEditForm/index.tsx
+++ b/src/features/member/components/MemberEditForm/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -8,33 +9,36 @@ import {
   CommonTextarea,
 } from '@/shared/components';
 import { useValidateForm } from '@/shared/hooks';
+import useUpdateImage from '../../hooks/useUpdateImage';
 import { AvatarBox, ButtonWrapper, Form, InputBox, InputWrapper } from './style';
 import { useCheckNickname, useUpateMemberInfo } from '@/features/member/hooks';
-import { PutMemberRequest } from '@/features/member/service';
 
 interface MemberEditFormProps {
   nickname: string;
+  image: string;
   introduction: string;
 }
 
-const MemberEditForm = ({ nickname, introduction }: MemberEditFormProps) => {
+const MemberEditForm = ({ nickname, image, introduction }: MemberEditFormProps) => {
   const navigate = useNavigate();
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors },
-  } = useForm<PutMemberRequest>({
+  } = useForm<MemberEditFormProps>({
     mode: 'onBlur',
     defaultValues: {
+      image,
       nickname,
       introduction,
     },
   });
   const registerOptions = useValidateForm();
   const checkNickname = useCheckNickname();
-  const [currentNickname] = watch(['nickname']);
+  const [currentNickname, currentImage] = watch(['nickname', 'image']);
   const updateMemberInfo = useUpateMemberInfo(currentNickname);
+  const updateImage = useUpdateImage();
 
   const handleCheckNickname = () => {
     if (errors.nickname) {
@@ -43,17 +47,28 @@ const MemberEditForm = ({ nickname, introduction }: MemberEditFormProps) => {
 
     checkNickname.mutate(currentNickname);
   };
-  const onSubmit: SubmitHandler<PutMemberRequest> = ({ nickname, introduction }) => {
+  const onSubmit: SubmitHandler<MemberEditFormProps> = ({ nickname, image, introduction }) => {
     updateMemberInfo.mutate({ nickname, introduction });
+    updateImage.mutate({ image });
   };
+
+  const [imagePreview, setImagePreview] = useState('');
+
+  useEffect(() => {
+    if (typeof currentImage !== 'string') {
+      const file = currentImage[0];
+      setImagePreview(URL.createObjectURL(file));
+    }
+  }, [currentImage]);
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <InputWrapper>
         <div>
           <CommonText type="strongInfo">프로필 사진</CommonText>
+          <input type="file" {...register('image')} />
           <AvatarBox>
-            <CommonAvatar isOwner />
+            <CommonAvatar src={imagePreview || image} isOwner />
           </AvatarBox>
         </div>
         <div>

--- a/src/features/member/components/MemberEditForm/style.ts
+++ b/src/features/member/components/MemberEditForm/style.ts
@@ -33,3 +33,7 @@ export const ButtonWrapper = styled.div`
   width: 100%;
   gap: 1rem;
 `;
+
+export const FileInput = styled.input`
+  display: none;
+`;

--- a/src/features/member/hooks/useUpdateImage.ts
+++ b/src/features/member/hooks/useUpdateImage.ts
@@ -1,14 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
-import { useCustomToast } from '@/shared/hooks';
-import { memberApi } from '../service';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { memberApi, memberQueryOption } from '../service';
 
 const useUpdateImage = () => {
-  const openToast = useCustomToast();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: memberApi.putMemberImage,
     onSuccess: () => {
-      openToast({ message: '프로필 이미지가 변경되었습니다.', type: 'success' });
+      queryClient.invalidateQueries({ queryKey: memberQueryOption.all });
     },
   });
 };

--- a/src/features/member/hooks/useUpdateImage.ts
+++ b/src/features/member/hooks/useUpdateImage.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCustomToast } from '@/shared/hooks';
+import { memberApi } from '../service';
+
+const useUpdateImage = () => {
+  const openToast = useCustomToast();
+
+  return useMutation({
+    mutationFn: memberApi.putMemberImage,
+    onSuccess: () => {
+      openToast({ message: '프로필 이미지가 변경되었습니다.', type: 'success' });
+    },
+  });
+};
+
+export default useUpdateImage;

--- a/src/features/member/service/handler.ts
+++ b/src/features/member/service/handler.ts
@@ -87,7 +87,11 @@ const memberApi = {
   putMemberImage: async ({ image }: PutMemberImageRequest) => {
     const url = `${BASE_URL}/profile/image`;
 
-    return await axiosClient.put<null>(url, { image });
+    return await axiosClient.put<null>(
+      url,
+      { image: image[0] },
+      { headers: { 'Content-Type': 'multipart/form-data' } }
+    );
   },
 
   deleteMember: async () => {

--- a/src/features/member/service/handler.ts
+++ b/src/features/member/service/handler.ts
@@ -5,6 +5,7 @@ import {
   PostLoginRequest,
   PostLoginResponse,
   PostSignupRequest,
+  PutMemberImageRequest,
   PutMemberRequest,
 } from './types';
 import { axiosClient } from '@/core/service/axios';
@@ -81,6 +82,12 @@ const memberApi = {
     const url = `${BASE_URL}/password`;
 
     return await axiosClient.put<null>(url, { password });
+  },
+
+  putMemberImage: async ({ image }: PutMemberImageRequest) => {
+    const url = `${BASE_URL}/profile/image`;
+
+    return await axiosClient.put<null>(url, { image });
   },
 
   deleteMember: async () => {

--- a/src/features/member/service/types.ts
+++ b/src/features/member/service/types.ts
@@ -38,3 +38,7 @@ export interface GetCheckJWTResponse {
   memberId: number;
   nickname: string;
 }
+
+export interface PutMemberImageRequest {
+  image: string;
+}

--- a/src/pages/Member/MemberEdit/index.tsx
+++ b/src/pages/Member/MemberEdit/index.tsx
@@ -25,7 +25,11 @@ const MemberEdit = () => {
       <Header type="back" />
       <Container>
         <CommonText type="normalTitle">프로필 수정</CommonText>
-        <MemberEditForm nickname={member.data.nickname} introduction={member.data.introduction} />
+        <MemberEditForm
+          image={member.data.profileImage}
+          nickname={member.data.nickname}
+          introduction={member.data.introduction}
+        />
       </Container>
     </>
   );

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -47,7 +47,7 @@ const MemberHome = () => {
       <Container>
         <MemberInfoWrapper>
           <MemberInfoPanel>
-            <CommonAvatar size="5rem" />
+            <CommonAvatar size="5rem" src={member.data?.memberProfile.profileImage} />
             <MemberInfoBox>
               <CommonText type="strongInfo">LV. {member.data?.memberProfile.level}</CommonText>
               <CommonText type="smallTitle">{nickname}</CommonText>

--- a/src/shared/components/Avatar/index.tsx
+++ b/src/shared/components/Avatar/index.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Box, Avatar, AvatarProps, Circle } from '@chakra-ui/react';
 import { CommonIcon } from '@/shared/components';
 
@@ -6,6 +7,7 @@ interface CommonAvatarProps {
   size: string;
   src: AvatarProps['src'];
   onClick: () => void;
+  children?: ReactNode;
 }
 
 const CommonAvatar = ({
@@ -13,6 +15,7 @@ const CommonAvatar = ({
   size,
   src = 'https://bit.ly/broken-link',
   onClick,
+  children,
 }: Partial<CommonAvatarProps>) => {
   const handleClick = () => {
     onClick && onClick();
@@ -22,7 +25,7 @@ const CommonAvatar = ({
     <>
       {isOwner ? (
         <Box position="relative" width="8em">
-          <Avatar src={src} size="8rem" />
+          <Avatar src={src} width="8rem" height="8rem" />
           <Circle
             size="8"
             bg="gray.100"
@@ -31,7 +34,10 @@ const CommonAvatar = ({
             right="0.45rem"
             onClick={handleClick}
           >
-            <CommonIcon type="pen" />
+            <label style={{ height: '1rem', cursor: 'pointer' }}>
+              <CommonIcon type="pen" />
+              {children}
+            </label>
           </Circle>
         </Box>
       ) : (

--- a/src/shared/types/member.ts
+++ b/src/shared/types/member.ts
@@ -8,6 +8,7 @@ export interface MemberInfo {
 export interface MemberProfile {
   memberId: number;
   nickname: string;
+  profileImage: string;
   level: number;
   introduction: string;
 }


### PR DESCRIPTION
## 구현(수정) 내용
프로필 이미지 수정 기능을 추가했습니다.

이미지의 크기가 크면 느리게 반영되는 이슈가 있습니다.
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

## 스크린샷
<img width="371" alt="스크린샷 2023-11-26 오후 7 46 56" src="https://github.com/bucket-back/bucket-back-frontend/assets/40534414/e170b73b-0e3b-403b-a853-fae4f9735617">

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
