### PR TITLE
[NO-JIRA] useIntersectionObserver 훅 추가

### DIFF
--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -5,3 +5,4 @@ export { default as useValidateForm } from './useValidateForm';
 export { default as useDrawer } from './useDrawer';
 export { default as useUserInfo } from './useUserInfo';
 export { default as useAuthNavigate } from './useAuthNavigate';
+export { default as useIntersectionObserver } from './useIntersectionObserver';

--- a/src/shared/hooks/useIntersectionObserver.ts
+++ b/src/shared/hooks/useIntersectionObserver.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseIntersectionObserverProps extends IntersectionObserverInit {
+  onObserve: () => void;
+}
+
+const useIntersectionObserver = ({ onObserve, ...options }: UseIntersectionObserverProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const callback: IntersectionObserverCallback = useCallback(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          onObserve();
+        }
+      });
+    },
+    [onObserve]
+  );
+
+  useEffect(() => {
+    const observedElement = ref.current;
+
+    if (!observedElement) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(callback, options);
+
+    observer.observe(observedElement);
+
+    return () => {
+      observer.unobserve(observedElement);
+    };
+  }, [callback, options]);
+
+  return ref;
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## 구현(수정) 내용
useIntersectionObserver 훅을 추가했습니다.

인수의 onObserve에는 fetchNextPage를 받으면되고 option은 선택적으로 추가하면 됩니다.

```javascript
const observedRef = useIntersectionObserver({ onObserve: feeds.fetchNextPage, root: (...) });
```

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
