### PR TITLE
[OMCT-390] 회원가입페이지 컴포넌트 분리, CommonText 수정

### DIFF
--- a/src/features/member/components/MemberEmailForm/index.tsx
+++ b/src/features/member/components/MemberEmailForm/index.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { CommonButton, CommonInput, CommonText } from '@/shared/components';
+import { useCustomToast, useValidateForm } from '@/shared/hooks';
+import { useCheckEmail } from '../../hooks';
+import { PostSignupRequest } from '../../service';
+import { InputAndButtonBox } from './style';
+import { submitValue } from '@/pages/Member/Signup';
+
+interface MemberEmailFormProps {
+  setSubmitValue: React.Dispatch<React.SetStateAction<submitValue>>;
+  emailAuthString: string;
+  email: string;
+}
+
+const MemberEmailForm = ({ setSubmitValue, emailAuthString, email }: MemberEmailFormProps) => {
+  const {
+    register,
+    resetField,
+    formState: { errors },
+  } = useFormContext<PostSignupRequest>();
+  const {
+    mutate: checkEmailMutate,
+    isSuccess: checkEmailSuccess,
+    data: checkEmailData,
+    isPending: checkEmailPending,
+  } = useCheckEmail();
+  const openToast = useCustomToast();
+  const registerOptions = useValidateForm();
+
+  const handleCheckEmail = () => {
+    if (errors.email || !email) {
+      return;
+    }
+    resetField('emailAuthString');
+    checkEmailMutate(email);
+  };
+
+  const handleEmailAuthNumber = () => {
+    if (emailAuthString == checkEmailData?.code) {
+      setSubmitValue((prev) => ({ ...prev, email: email }));
+      openToast({ message: '인증되었습니다.', type: 'success' });
+    } else {
+      openToast({ message: '안증번호가 일치하지않습니다.', type: 'error' });
+    }
+  };
+
+  return (
+    <>
+      <CommonText type="strongInfo">이메일</CommonText>
+      <InputAndButtonBox>
+        <CommonInput
+          width="100%"
+          type="text"
+          placeholder="이메일을 입력해주세요."
+          error={errors.email}
+          {...register('email', ...registerOptions.email)}
+        />
+
+        <CommonButton
+          type="mdBase"
+          width="fit-content"
+          onClick={handleCheckEmail}
+          isDisabled={checkEmailPending}
+        >
+          인증
+        </CommonButton>
+      </InputAndButtonBox>
+      {checkEmailSuccess && (
+        <InputAndButtonBox>
+          <CommonInput
+            width="100%"
+            type="text"
+            placeholder="인증번호를 입력해주세요."
+            error={errors.emailAuthString}
+            {...register('emailAuthString', { required: '인증번호 입력은 필수입니다.' })}
+          />
+          <CommonButton type="mdBase" width="fit-content" onClick={handleEmailAuthNumber}>
+            확인
+          </CommonButton>
+        </InputAndButtonBox>
+      )}
+    </>
+  );
+};
+
+export default MemberEmailForm;

--- a/src/features/member/components/MemberEmailForm/style.ts
+++ b/src/features/member/components/MemberEmailForm/style.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const InputAndButtonBox = styled.div`
+  display: flex;
+  align-items: start;
+  gap: 0.2rem;
+`;

--- a/src/features/member/components/MemberNicknameForm/index.tsx
+++ b/src/features/member/components/MemberNicknameForm/index.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { CommonButton, CommonInput, CommonText } from '@/shared/components';
+import { useValidateForm } from '@/shared/hooks';
+import { useCheckNickname } from '../../hooks';
+import { InputAndButtonBox } from './style';
+import { PostSignupRequest } from '@/features/member/service';
+import { submitValue } from '@/pages/Member/Signup';
+
+interface MemberNicknameFormProps {
+  setSubmitValue: React.Dispatch<React.SetStateAction<submitValue>>;
+  nickname: string;
+}
+
+const MemberNicknameForm = ({ setSubmitValue, nickname }: MemberNicknameFormProps) => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<PostSignupRequest>();
+  const registerOptions = useValidateForm();
+  const {
+    mutate: checkNicknameMutate,
+    isSuccess: checkNicknameSuccess,
+    isPending: checkNicknamePending,
+  } = useCheckNickname();
+
+  const handleCheckNickname = () => {
+    if (errors.nickname || !nickname) {
+      return;
+    }
+    checkNicknameMutate(nickname);
+  };
+
+  useEffect(() => {
+    if (checkNicknameSuccess) {
+      setSubmitValue((prev) => ({ ...prev, nickname: nickname }));
+    }
+  }, [checkNicknameSuccess]);
+
+  return (
+    <>
+      <CommonText type="strongInfo">닉네임</CommonText>
+      <InputAndButtonBox>
+        <CommonInput
+          type="text"
+          width="100%"
+          placeholder="닉네임을 입력해주세요."
+          error={errors.nickname}
+          {...register('nickname', ...registerOptions.nickname)}
+        />
+        <CommonButton
+          type="mdBase"
+          width="fit-content"
+          onClick={handleCheckNickname}
+          isDisabled={checkNicknamePending}
+        >
+          중복확인
+        </CommonButton>
+      </InputAndButtonBox>
+    </>
+  );
+};
+export default MemberNicknameForm;

--- a/src/features/member/components/MemberNicknameForm/style.ts
+++ b/src/features/member/components/MemberNicknameForm/style.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const InputAndButtonBox = styled.div`
+  display: flex;
+  align-items: start;
+  gap: 0.2rem;
+`;

--- a/src/features/member/components/MemberPassword/index.tsx
+++ b/src/features/member/components/MemberPassword/index.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { CommonIcon, CommonInput } from '@/shared/components';
+import { useValidateForm } from '@/shared/hooks';
+import { PostSignupRequest } from '../../service';
+import { IconWrapper } from '@/pages/Member/Login/style';
+
+const MemberPassword = () => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<PostSignupRequest>();
+  const registerOptions = useValidateForm();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+
+  return (
+    <>
+      <CommonInput
+        width="100%"
+        label="비밀번호"
+        type={showPassword ? 'text' : 'password'}
+        placeholder="비밀번호를 입력해주세요."
+        error={errors.password}
+        rightIcon={
+          <IconWrapper onClick={() => setShowPassword(() => !showPassword)}>
+            <CommonIcon type={showPassword ? 'eye' : 'eyeSlash'} size="1.25rem" />
+          </IconWrapper>
+        }
+        {...register('password', ...registerOptions.password)}
+      />
+      <CommonInput
+        width="100%"
+        type={showPasswordConfirm ? 'text' : 'password'}
+        placeholder="비밀번호를 확인해주세요."
+        error={errors.passwordConfirm}
+        rightIcon={
+          <IconWrapper onClick={() => setShowPasswordConfirm(() => !showPasswordConfirm)}>
+            <CommonIcon type={showPasswordConfirm ? 'eye' : 'eyeSlash'} size="1.25rem" />
+          </IconWrapper>
+        }
+        {...register('passwordConfirm', {
+          required: '비밀번호 확인은 필수입니다.',
+          validate: (value: string, { password }: { password: string }) =>
+            value === password || '비밀번호가 동일하지 않습니다.',
+        })}
+      />
+    </>
+  );
+};
+
+export default MemberPassword;

--- a/src/pages/Member/Signup/index.tsx
+++ b/src/pages/Member/Signup/index.tsx
@@ -1,178 +1,61 @@
-import { useEffect, useState } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
-import { CommonButton, CommonIcon, CommonInput, CommonText } from '@/shared/components';
+import { useState } from 'react';
+import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
+import { CommonButton } from '@/shared/components';
 import { useCustomToast } from '@/shared/hooks';
-import { Container, Form, IconWrapper, InputAndButtonBox, InputWrapper } from './style';
-import { useCheckEmail, useCheckNickname, useSignup } from '@/features/member/hooks';
+import { Container, Form, InputWrapper } from './style';
+import MemberEmailForm from '@/features/member/components/MemberEmailForm';
+import MemberNicknameForm from '@/features/member/components/MemberNicknameForm';
+import MemberPassword from '@/features/member/components/MemberPassword';
+import { useSignup } from '@/features/member/hooks';
 import { PostSignupRequest } from '@/features/member/service';
-import useValidateForm from '@/shared/hooks/useValidateForm';
+
+export interface submitValue {
+  email: string;
+  nickname: string;
+}
 
 const SignUp = () => {
-  const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { errors },
-    resetField,
-  } = useForm<PostSignupRequest>({ mode: 'onBlur' });
-  const [showPassword, setShowPassword] = useState(false);
+  const methods = useForm<PostSignupRequest>({ mode: 'onBlur' });
   const openToast = useCustomToast();
-  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
   const { mutate: signupMutate } = useSignup();
-  const {
-    mutate: checkNicknameMutate,
-    isSuccess: checkNicknameSuccess,
-    isPending: checkNicknamePending,
-  } = useCheckNickname();
-  const {
-    mutate: checkEmailMutate,
-    isSuccess: checkEmailSuccess,
-    data: checkEmailData,
-    isPending: checkEmailPending,
-  } = useCheckEmail();
-  const registerOptions = useValidateForm();
-  const [nickname, email, emailAuthString] = watch(['nickname', 'email', 'emailAuthString']);
-  const [submitValue, setSubmitValue] = useState({ email: '', nickname: '' });
+  const [nickname, email, emailAuthString] = methods.watch([
+    'nickname',
+    'email',
+    'emailAuthString',
+  ]);
+  const [submitValue, setSubmitValue] = useState<submitValue>({ email: '', nickname: '' });
 
   const onSubmit: SubmitHandler<PostSignupRequest> = (data) => {
-    if (
-      checkEmailSuccess &&
-      checkNicknameSuccess &&
-      email === submitValue.email &&
-      nickname === submitValue.nickname
-    ) {
+    if (email === submitValue.email && nickname === submitValue.nickname) {
       signupMutate(data);
     } else {
       openToast({ message: '인증 절차를 다시한번 더 확인해주세요.', type: 'error' });
     }
   };
 
-  const handleCheckNickname = () => {
-    if (errors.nickname || !nickname) {
-      return;
-    }
-    checkNicknameMutate(nickname);
-  };
-
-  const handleCheckEmail = () => {
-    if (errors.email || !email) {
-      return;
-    }
-    resetField('emailAuthString');
-    checkEmailMutate(email);
-  };
-
-  const handleEmailAuthNumber = () => {
-    if (emailAuthString == checkEmailData?.code) {
-      setSubmitValue((prev) => ({ ...prev, email: email }));
-      openToast({ message: '인증되었습니다.', type: 'success' });
-    } else {
-      openToast({ message: '안증번호가 일치하지않습니다.', type: 'error' });
-    }
-  };
-
-  useEffect(() => {
-    if (checkNicknameSuccess) {
-      setSubmitValue((prev) => ({ ...prev, nickname: nickname }));
-    }
-  }, [checkNicknameSuccess]);
-
   return (
-    <Container>
-      <Form onSubmit={handleSubmit(onSubmit)}>
-        <InputWrapper>
-          <CommonText type="strongInfo">이메일</CommonText>
-          <InputAndButtonBox>
-            <CommonInput
-              width="100%"
-              type="text"
-              placeholder="이메일을 입력해주세요."
-              error={errors.email}
-              {...register('email', ...registerOptions.email)}
+    <FormProvider {...methods}>
+      <Container>
+        <Form onSubmit={methods.handleSubmit(onSubmit)}>
+          <InputWrapper>
+            <MemberEmailForm
+              setSubmitValue={setSubmitValue}
+              emailAuthString={emailAuthString}
+              email={email}
             />
-
-            <CommonButton
-              type="mdBase"
-              width="fit-content"
-              onClick={handleCheckEmail}
-              isDisabled={checkEmailPending}
-            >
-              인증
-            </CommonButton>
-          </InputAndButtonBox>
-          {checkEmailSuccess && (
-            <InputAndButtonBox>
-              <CommonInput
-                width="100%"
-                type="text"
-                placeholder="인증번호를 입력해주세요."
-                error={errors.emailAuthString}
-                {...register('emailAuthString', { required: '인증번호 입력은 필수입니다.' })}
-              />
-              <CommonButton type="mdBase" width="fit-content" onClick={handleEmailAuthNumber}>
-                확인
-              </CommonButton>
-            </InputAndButtonBox>
-          )}
-        </InputWrapper>
-
-        <InputWrapper>
-          <CommonInput
-            width="100%"
-            label="비밀번호"
-            type={showPassword ? 'text' : 'password'}
-            placeholder="비밀번호를 입력해주세요."
-            error={errors.password}
-            rightIcon={
-              <IconWrapper onClick={() => setShowPassword(() => !showPassword)}>
-                <CommonIcon type={showPassword ? 'eye' : 'eyeSlash'} size="1.25rem" />
-              </IconWrapper>
-            }
-            {...register('password', ...registerOptions.password)}
-          />
-          <CommonInput
-            width="100%"
-            type={showPasswordConfirm ? 'text' : 'password'}
-            placeholder="비밀번호를 확인해주세요."
-            error={errors.passwordConfirm}
-            rightIcon={
-              <IconWrapper onClick={() => setShowPasswordConfirm(() => !showPasswordConfirm)}>
-                <CommonIcon type={showPasswordConfirm ? 'eye' : 'eyeSlash'} size="1.25rem" />
-              </IconWrapper>
-            }
-            {...register('passwordConfirm', {
-              required: '비밀번호 확인은 필수입니다.',
-              validate: (value, { password }) =>
-                value === password || '비밀번호가 동일하지 않습니다.',
-            })}
-          />
-        </InputWrapper>
-
-        <InputWrapper>
-          <CommonText type="strongInfo">닉네임</CommonText>
-          <InputAndButtonBox>
-            <CommonInput
-              type="text"
-              width="100%"
-              placeholder="닉네임을 입력해주세요."
-              error={errors.nickname}
-              {...register('nickname', ...registerOptions.nickname)}
-            />
-            <CommonButton
-              type="mdBase"
-              width="fit-content"
-              onClick={handleCheckNickname}
-              isDisabled={checkNicknamePending}
-            >
-              중복확인
-            </CommonButton>
-          </InputAndButtonBox>
-        </InputWrapper>
-        <CommonButton type="mdFull" isSubmit={true}>
-          회원가입
-        </CommonButton>
-      </Form>
-    </Container>
+          </InputWrapper>
+          <InputWrapper>
+            <MemberPassword />
+          </InputWrapper>
+          <InputWrapper>
+            <MemberNicknameForm setSubmitValue={setSubmitValue} nickname={nickname} />
+          </InputWrapper>
+          <CommonButton type="mdFull" isSubmit={true}>
+            회원가입
+          </CommonButton>
+        </Form>
+      </Container>
+    </FormProvider>
   );
 };
 

--- a/src/shared/components/Text/index.tsx
+++ b/src/shared/components/Text/index.tsx
@@ -11,9 +11,9 @@ interface CommonTextProps {
 }
 
 const TEXT_TYPE = {
-  strongTitle: { fontSize: '3rem', weight: 700 },
-  normalTitle: { fontSize: '1.5rem', weight: 700 },
-  smallTitle: { fontSize: '1.25rem', weight: 700 },
+  strongTitle: { fontSize: '3rem' },
+  normalTitle: { fontSize: '1.5rem' },
+  smallTitle: { fontSize: '1.25rem' },
   strongInfo: { fontSize: '1rem', weight: 700 },
   subStrongInfo: { fontSize: '1.125rem', weight: 400 },
   normalInfo: { fontSize: '0.875rem', weight: 500 },

--- a/src/shared/components/Text/index.tsx
+++ b/src/shared/components/Text/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Heading, Text } from '@chakra-ui/react';
+import { Text } from '@chakra-ui/react';
 import { conformText } from '@/shared/utils/';
 
 interface CommonTextProps {
@@ -7,6 +7,7 @@ interface CommonTextProps {
   color?: string;
   noOfLines?: number | number[];
   children: ReactNode;
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const TEXT_TYPE = {
@@ -20,13 +21,19 @@ const TEXT_TYPE = {
   smallInfo: { fontSize: '0.75rem', weight: 400 },
 };
 
-const CommonText = ({ type, color = 'inherit', noOfLines = 1, children }: CommonTextProps) => {
+const CommonText = ({
+  type,
+  color = 'inherit',
+  noOfLines = 1,
+  as = 'h2',
+  children,
+}: CommonTextProps) => {
   return (
     <>
       {conformText(type, 'title') ? (
-        <Heading color={color} noOfLines={noOfLines} fontFamily="Inter" {...TEXT_TYPE[type]}>
+        <Text as={as} color={color} noOfLines={noOfLines} {...TEXT_TYPE[type]}>
           {children}
-        </Heading>
+        </Text>
       ) : (
         <Text color={color} noOfLines={noOfLines} {...TEXT_TYPE[type]}>
           {children}

--- a/src/shared/styles/GlobalStyle.tsx
+++ b/src/shared/styles/GlobalStyle.tsx
@@ -1,8 +1,19 @@
 import { Global, css } from '@emotion/react';
+import { COMMON } from './Common';
 
 const style = css`
   body {
     font-family: 'Cafe24Regular';
+    color: ${COMMON.COLORS.FONT_COLOR};
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: 'Cafe24Bold';
+    color: ${COMMON.COLORS.FONT_COLOR};
   }
 `;
 


### PR DESCRIPTION
## 구현(수정) 내용
1. CommonText에 as props를 추가했습니다.
2. 회원가입페이지에 컴포넌트를 분리하였습니다. => 지금은 종속성이 강해서 추후에 제거할 예정입니다.!

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
