### PR TITLE
[OMCT-388] 버킷 관련 무한 스크롤 구현, QA 반영, 새로운 api 명세 반영

### DIFF
--- a/src/features/bucket/components/BucketList/index.tsx
+++ b/src/features/bucket/components/BucketList/index.tsx
@@ -4,7 +4,7 @@ import { CommonText, DividerImage } from '@/shared/components';
 import { useIntersectionObserver } from '@/shared/hooks';
 import { formatNumber } from '@/shared/utils';
 import { bucketQueryOption } from '../../service';
-import { BucketWrapper, Container, NoResult } from './style';
+import { BucketBox, BucketWrapper, Container, NoResult, TotalCountWrapper } from './style';
 
 interface BucketListProps {
   nickname: string;
@@ -32,16 +32,23 @@ const BucketList = ({ nickname, hobby }: BucketListProps) => {
 
   return (
     <Container>
-      {bucket.data.pages.map((page) =>
-        page.buckets.map((bucket) => (
-          <BucketWrapper key={bucket.bucketId} onClick={() => navigate(`./${bucket.bucketId}`)}>
-            <DividerImage type="base" images={bucket.itemImages.map(({ imgUrl }) => imgUrl)} />
-            <CommonText type="smallInfo">{bucket.name}</CommonText>
-            <CommonText type="smallInfo">{formatNumber(bucket.totalPrice)}</CommonText>
-          </BucketWrapper>
-        ))
-      )}
-      {bucket.hasNextPage && <div ref={observedRef} />}
+      <TotalCountWrapper>
+        <CommonText type="smallInfo">
+          총 {bucket.data.pages[0].totalBucketCount}개의 버킷
+        </CommonText>
+      </TotalCountWrapper>
+      <BucketWrapper>
+        {bucket.data.pages.map((page) =>
+          page.buckets.map((bucket) => (
+            <BucketBox key={bucket.bucketId} onClick={() => navigate(`./${bucket.bucketId}`)}>
+              <DividerImage type="base" images={bucket.itemImages.map(({ imgUrl }) => imgUrl)} />
+              <CommonText type="smallInfo">{bucket.name}</CommonText>
+              <CommonText type="smallInfo">{formatNumber(bucket.totalPrice)}</CommonText>
+            </BucketBox>
+          ))
+        )}
+        {bucket.hasNextPage && <div ref={observedRef} />}
+      </BucketWrapper>
     </Container>
   );
 };

--- a/src/features/bucket/components/BucketList/index.tsx
+++ b/src/features/bucket/components/BucketList/index.tsx
@@ -14,7 +14,7 @@ interface BucketListProps {
 const BucketList = ({ nickname, hobby }: BucketListProps) => {
   const navigate = useNavigate();
 
-  const bucket = useInfiniteQuery(bucketQueryOption.infiniteList({ nickname, hobby, size: 18 }));
+  const bucket = useInfiniteQuery(bucketQueryOption.list({ nickname, hobby, size: 18 }));
 
   const observedRef = useIntersectionObserver({ onObserve: bucket.fetchNextPage });
 

--- a/src/features/bucket/components/BucketList/index.tsx
+++ b/src/features/bucket/components/BucketList/index.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { CommonText, DividerImage } from '@/shared/components';
+import { useIntersectionObserver } from '@/shared/hooks';
+import { formatNumber } from '@/shared/utils';
+import { bucketQueryOption } from '../../service';
+import { BucketWrapper, Container, NoResult } from './style';
+
+interface BucketListProps {
+  nickname: string;
+  hobby: string;
+}
+
+const BucketList = ({ nickname, hobby }: BucketListProps) => {
+  const navigate = useNavigate();
+
+  const bucket = useInfiniteQuery(bucketQueryOption.infiniteList({ nickname, hobby, size: 18 }));
+
+  const observedRef = useIntersectionObserver({ onObserve: bucket.fetchNextPage });
+
+  if (bucket.isPending) {
+    return;
+  }
+
+  if (bucket.isError) {
+    return;
+  }
+
+  if (bucket.data.pages[0].buckets.length === 0) {
+    return <NoResult>버킷이 없습니다.</NoResult>;
+  }
+
+  return (
+    <Container>
+      {bucket.data.pages.map((page) =>
+        page.buckets.map((bucket) => (
+          <BucketWrapper key={bucket.bucketId} onClick={() => navigate(`./${bucket.bucketId}`)}>
+            <DividerImage type="base" images={bucket.itemImages.map(({ imgUrl }) => imgUrl)} />
+            <CommonText type="smallInfo">{bucket.name}</CommonText>
+            <CommonText type="smallInfo">{formatNumber(bucket.totalPrice)}</CommonText>
+          </BucketWrapper>
+        ))
+      )}
+      {bucket.hasNextPage && <div ref={observedRef} />}
+    </Container>
+  );
+};
+
+export default BucketList;

--- a/src/features/bucket/components/BucketList/style.ts
+++ b/src/features/bucket/components/BucketList/style.ts
@@ -1,7 +1,17 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  max-height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TotalCountWrapper = styled.div`
+  padding: 1rem 1rem 0 2rem;
+`;
+
+export const BucketWrapper = styled.div`
+  height: 100%;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 0.5rem;
@@ -9,7 +19,7 @@ export const Container = styled.div`
   overflow-y: auto;
 `;
 
-export const BucketWrapper = styled.div`
+export const BucketBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/features/bucket/components/BucketList/style.ts
+++ b/src/features/bucket/components/BucketList/style.ts
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  max-height: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  padding: 1rem 2rem 1rem 2rem;
+  overflow-y: auto;
+`;
+
+export const BucketWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const NoResult = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/features/bucket/components/BucketSelectItem/index.tsx
+++ b/src/features/bucket/components/BucketSelectItem/index.tsx
@@ -49,7 +49,7 @@ const BucketSelectItem = ({ items, onClick }: BucketSelectItemPorps) => {
               <ImageLabel htmlFor={String(itemInfo.id)}>
                 <CommonImage size="sm" src={itemInfo.image} />
               </ImageLabel>
-              <CommonText type="normalInfo">{formatNumber(itemInfo.price)}원</CommonText>
+              <CommonText type="normalInfo">{formatNumber(itemInfo.price)}</CommonText>
               <CommonText type="smallInfo">{itemInfo.name}</CommonText>
             </ItemBox>
           ))}

--- a/src/features/bucket/components/BucketSelectItem/index.tsx
+++ b/src/features/bucket/components/BucketSelectItem/index.tsx
@@ -37,7 +37,7 @@ const BucketSelectItem = ({ items, onClick }: BucketSelectItemPorps) => {
     <>
       <Body>
         <CommonText type="normalTitle">아이템 선택</CommonText>
-        <CommonText type="subStrongInfo">총 {items.totalCount}개의 아이템</CommonText>
+        <CommonText type="subStrongInfo">총 {items.totalMemberItemCount}개의 아이템</CommonText>
         <ItemsWrapper>
           {items.summaries.map(({ itemInfo }) => (
             <ItemBox key={itemInfo.id}>
@@ -60,7 +60,7 @@ const BucketSelectItem = ({ items, onClick }: BucketSelectItemPorps) => {
             <div>
               <CommonText type="smallInfo">원하시는 아이템이 없나요?</CommonText>
               <Container>
-                <CommonButton type="text" onClick={() => navigate('/item')}>
+                <CommonButton type="text" onClick={() => navigate('/search')}>
                   아이템 추가하러가기
                 </CommonButton>
                 <CommonIcon type="chevronRight" />

--- a/src/features/bucket/components/BucketUpdateItem/index.tsx
+++ b/src/features/bucket/components/BucketUpdateItem/index.tsx
@@ -41,7 +41,7 @@ const BucketUpdateItem = ({ items, selectedItems, onClick }: BucketUpdateItemPro
             <ImageLabel htmlFor={String(itemInfo.id)}>
               <CommonImage size="sm" src={itemInfo.image} />
             </ImageLabel>
-            <CommonText type="normalInfo">{formatNumber(itemInfo.price)}원</CommonText>
+            <CommonText type="normalInfo">{formatNumber(itemInfo.price)}</CommonText>
             <CommonText type="smallInfo">{itemInfo.name}</CommonText>
           </ItemBox>
         ))}

--- a/src/features/bucket/components/BucketUpdateItem/index.tsx
+++ b/src/features/bucket/components/BucketUpdateItem/index.tsx
@@ -28,7 +28,7 @@ const BucketUpdateItem = ({ items, selectedItems, onClick }: BucketUpdateItemPro
   return (
     <Container>
       <CommonText type="normalTitle">아이템 선택</CommonText>
-      <CommonText type="subStrongInfo">총 {items.totalCount}개의 아이템</CommonText>
+      <CommonText type="subStrongInfo">총 {items.totalMemberItemCount}개의 아이템</CommonText>
       <ItemsWrapper>
         {items.summaries.map(({ itemInfo }) => (
           <ItemBox key={itemInfo.id}>

--- a/src/features/bucket/components/index.ts
+++ b/src/features/bucket/components/index.ts
@@ -1,3 +1,4 @@
 export { default as BucketSelectItem } from './BucketSelectItem';
 export { default as BucketUpdateItem } from './BucketUpdateItem';
 export { default as BucketSelectedItems } from './BucketSelectedItems';
+export { default as BucketList } from './BucketList';

--- a/src/features/bucket/service/queryOption.ts
+++ b/src/features/bucket/service/queryOption.ts
@@ -4,15 +4,9 @@ import { GetBucketDetailRequest, GetBucketMyItemsRequest, GetBucketsRequest, buc
 const bucketQueryOption = {
   all: ['bucket'] as const,
 
-  list: ({ nickname, hobby, cursorId, size = 10 }: GetBucketsRequest) =>
-    queryOptions({
-      queryKey: [...bucketQueryOption.all, nickname, hobby] as const,
-      queryFn: () => bucketApi.getBuckets({ nickname, hobby, cursorId, size }),
-    }),
-
-  infiniteList: ({ nickname, hobby, size = 10 }: GetBucketsRequest) =>
+  list: ({ nickname, hobby, size = 10 }: GetBucketsRequest) =>
     infiniteQueryOptions({
-      queryKey: [...bucketQueryOption.all, nickname, hobby, 'infinite'] as const,
+      queryKey: [...bucketQueryOption.all, nickname, hobby] as const,
       queryFn: ({ pageParam: cursorId }) =>
         bucketApi.getBuckets({ nickname, hobby, cursorId, size }),
       initialPageParam: '',

--- a/src/features/bucket/service/queryOption.ts
+++ b/src/features/bucket/service/queryOption.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import { GetBucketDetailRequest, GetBucketMyItemsRequest, GetBucketsRequest, bucketApi } from '.';
 
 const bucketQueryOption = {
@@ -8,6 +8,15 @@ const bucketQueryOption = {
     queryOptions({
       queryKey: [...bucketQueryOption.all, nickname, hobby] as const,
       queryFn: () => bucketApi.getBuckets({ nickname, hobby, cursorId, size }),
+    }),
+
+  infiniteList: ({ nickname, hobby, size = 10 }: GetBucketsRequest) =>
+    infiniteQueryOptions({
+      queryKey: [...bucketQueryOption.all, nickname, hobby, 'infinite'] as const,
+      queryFn: ({ pageParam: cursorId }) =>
+        bucketApi.getBuckets({ nickname, hobby, cursorId, size }),
+      initialPageParam: '',
+      getNextPageParam: ({ nextCursorId }) => nextCursorId,
     }),
 
   detail: ({ nickname, bucketId }: GetBucketDetailRequest) =>

--- a/src/features/bucket/service/types.ts
+++ b/src/features/bucket/service/types.ts
@@ -9,6 +9,7 @@ export interface GetBucketsRequest {
 
 export interface GetBucketsResponse {
   nextCursorId: string;
+  totalBucketCount: number;
   buckets: Bucket[];
 }
 

--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -61,7 +61,7 @@ const CommentItem = ({
           </CommonButton>
           {isOwnFeed && !hasAdoptedComment && userInfo?.nickname !== memberInfo.nickName && (
             <CommonButton type="xsText" onClick={() => adoptComment.mutate({ feedId, commentId })}>
-              채택하기
+              • 채택하기
             </CommonButton>
           )}
         </InteractPanel>

--- a/src/features/comment/hooks/useAddComment.ts
+++ b/src/features/comment/hooks/useAddComment.ts
@@ -1,8 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCustomToast } from '@/shared/hooks';
 import { commentApi, commentQueryQption } from '../service';
+import { feedQueryOption } from '@/features/feed/service';
 
-const useAddComment = () => {
+const useAddComment = (feedId: number) => {
   const queryClient = useQueryClient();
   const openToast = useCustomToast();
 
@@ -10,6 +11,7 @@ const useAddComment = () => {
     mutationFn: commentApi.postComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentQueryQption.all });
+      queryClient.invalidateQueries({ queryKey: feedQueryOption.detail(feedId).queryKey });
       openToast({ message: '댓글이 추가되었습니다.', type: 'success' });
     },
   });

--- a/src/features/comment/service/types.ts
+++ b/src/features/comment/service/types.ts
@@ -9,6 +9,7 @@ export interface GetCommentsRequest {
 export interface GetCommentsResponse {
   nextCursorId: string;
   totalCount: number;
+  totalCommentCount: number;
   comments: Comment[];
 }
 

--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -91,7 +91,7 @@ const FeedItem = ({
           />
         )}
       </ProfileWrapper>
-      <ContentsWrapper>
+      <ContentsWrapper onClick={() => onClick(feedId)}>
         {feedContent && (
           <CommonText type="normalInfo" color="inherit" noOfLines={isDetail ? 10 : 3}>
             {feedContent}
@@ -101,14 +101,14 @@ const FeedItem = ({
           <BucketInfoBox>
             <CommonText type="smallInfo">버킷명: {bucketName}</CommonText>
             {totalPrice && (
-              <CommonText type="smallInfo">버킷 총액: {formatNumber(totalPrice)}원</CommonText>
+              <CommonText type="smallInfo">버킷 총액: {formatNumber(totalPrice)}</CommonText>
             )}
             {bucketBudget && (
-              <CommonText type="smallInfo">예산: {formatNumber(bucketBudget)}원</CommonText>
+              <CommonText type="smallInfo">예산: {formatNumber(bucketBudget)}</CommonText>
             )}
           </BucketInfoBox>
         )}
-        <ImageBox onClick={() => onClick(feedId)}>
+        <ImageBox>
           {feedItems.map((item) => (
             <CommonImage key={item.id} size="sm" src={item.image} />
           ))}

--- a/src/features/feed/components/FeedItem/index.tsx
+++ b/src/features/feed/components/FeedItem/index.tsx
@@ -117,7 +117,12 @@ const FeedItem = ({
           <DateText createdDate={createdAt} />
           <InteractPanel>
             {isDetail ? (
-              <CommonButton type="sm" isLike={isLike} onClick={handleClickLike}>
+              <CommonButton
+                type="sm"
+                isLike={isLike}
+                onClick={handleClickLike}
+                isDisabled={feedLike.isPending || feedUnLike.isPending}
+              >
                 {String(likeCount)}
               </CommonButton>
             ) : (

--- a/src/features/feed/components/FeedItem/style.tsx
+++ b/src/features/feed/components/FeedItem/style.tsx
@@ -19,6 +19,7 @@ export const ContentsWrapper = styled.div`
   flex-direction: column;
   gap: 0.3rem;
   padding: 0 2.5rem;
+  cursor: pointer;
 `;
 
 export const BucketInfoBox = styled.div`

--- a/src/features/feed/components/FeedItemsDetail/index.tsx
+++ b/src/features/feed/components/FeedItemsDetail/index.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from 'react-router-dom';
-import { CommonButton, CommonImage } from '@/shared/components';
+import { CommonButton, CommonImage, CommonText } from '@/shared/components';
 import { FeedItemInfo } from '@/shared/types';
-import { ellipsisName } from '@/shared/utils';
-import { ButtonBox, Container, ContentsWrapper } from './style';
+import { ellipsisName, formatNumber } from '@/shared/utils';
+import { ButtonBox, Container, ContentsWrapper, ImageBox, PriceBox } from './style';
 
 interface FeedItemsDetailProps {
-  items?: FeedItemInfo[];
+  items: FeedItemInfo[];
 }
 
 const FeedItemsDetail = ({ items }: FeedItemsDetailProps) => {
@@ -18,7 +18,7 @@ const FeedItemsDetail = ({ items }: FeedItemsDetailProps) => {
   return (
     <Container>
       {items &&
-        items.map(({ id, name, image }) => (
+        items.map(({ id, name, image, price }) => (
           <ContentsWrapper key={id}>
             <ButtonBox>
               <CommonImage size="xs" src={image} />
@@ -26,7 +26,12 @@ const FeedItemsDetail = ({ items }: FeedItemsDetailProps) => {
                 {ellipsisName(name, 25)}
               </CommonButton>
             </ButtonBox>
-            <CommonImage size="lg" src={image} onClick={() => handleClick(id)} />
+            <PriceBox>
+              <CommonText type="normalInfo">{formatNumber(price)}</CommonText>
+            </PriceBox>
+            <ImageBox>
+              <CommonImage size="lg" src={image} onClick={() => handleClick(id)} />
+            </ImageBox>
           </ContentsWrapper>
         ))}
     </Container>

--- a/src/features/feed/components/FeedItemsDetail/style.tsx
+++ b/src/features/feed/components/FeedItemsDetail/style.tsx
@@ -11,11 +11,20 @@ export const Container = styled.div`
 export const ContentsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 `;
 
 export const ButtonBox = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+`;
+
+export const PriceBox = styled.div`
+  display: flex;
+  justify-content: end;
+`;
+
+export const ImageBox = styled.div`
+  border: 1px solid #e2e8f0;
 `;

--- a/src/features/feed/components/FeedMemberList/index.tsx
+++ b/src/features/feed/components/FeedMemberList/index.tsx
@@ -59,7 +59,7 @@ const FeedMemberList = ({ hobbyName, nickname, onlyNicknameLikeFeeds }: FeedMemb
                 createdAt={createdAt}
                 feedItems={feedItems}
                 isDetail={false}
-                onClick={() => navigate(`./${feedId}`)}
+                onClick={() => navigate(`/feed/${feedId}`)}
               />
               <CommonDivider size="sm" />
             </Fragment>

--- a/src/features/feed/components/FeedSelectBucket/index.tsx
+++ b/src/features/feed/components/FeedSelectBucket/index.tsx
@@ -61,7 +61,7 @@ const FeedSelectBucket = ({ hobby, nickname, selectedBucket, onClick }: FeedSele
       <TitleWrapper>
         <CommonText type="normalTitle">버킷 선택하기</CommonText>
         <CommonText type="subStrongInfo">
-          총 {bucketList.data.pages[0].buckets.length}개의 버킷
+          총 {bucketList.data.pages[0].totalBucketCount}개의 버킷
         </CommonText>
       </TitleWrapper>
       {bucketList.data.pages[0].buckets.length === 0 && (

--- a/src/features/feed/components/FeedSelectBucket/index.tsx
+++ b/src/features/feed/components/FeedSelectBucket/index.tsx
@@ -44,9 +44,7 @@ const reduceImgUrl = (itemImages: ItemImages[]) => {
 const FeedSelectBucket = ({ hobby, nickname, selectedBucket, onClick }: FeedSelectBucketProps) => {
   const navigate = useNavigate();
 
-  const bucketList = useInfiniteQuery(
-    bucketQueryOption.infiniteList({ hobby, nickname, size: 18 })
-  );
+  const bucketList = useInfiniteQuery(bucketQueryOption.list({ hobby, nickname, size: 18 }));
 
   const observedRef = useIntersectionObserver({ onObserve: bucketList.fetchNextPage });
 

--- a/src/features/feed/components/FeedSelectBucket/index.tsx
+++ b/src/features/feed/components/FeedSelectBucket/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import {
   CommonButton,
   CommonDivider,
@@ -7,12 +8,13 @@ import {
 } from '@/shared/components';
 import {
   Container,
-  ContentsWrapper,
   BucketListWrapper,
   BucketBox,
   AddBucketButtonBox,
   ImageInput,
   ImageLabel,
+  AddBucketWrapper,
+  TitleWrapper,
 } from './style';
 import { GetBucketsResponse } from '@/features/bucket/service';
 
@@ -37,12 +39,14 @@ const reduceImgUrl = (itemImages: ItemImages[]) => {
 };
 
 const FeedSelectBucket = ({ selectedBucket, bucketList, onClick }: FeedSelectBucketProps) => {
+  const navigate = useNavigate();
+
   return (
     <Container>
-      <ContentsWrapper>
+      <TitleWrapper style={{ paddingBottom: '1rem' }}>
         <CommonText type="normalTitle">버킷 선택하기</CommonText>
         <CommonText type="subStrongInfo">총 {bucketList.buckets.length}개의 버킷</CommonText>
-      </ContentsWrapper>
+      </TitleWrapper>
       {bucketList.buckets.length > 0 ? (
         <BucketListWrapper>
           {bucketList.buckets.map((bucket) => (
@@ -69,13 +73,13 @@ const FeedSelectBucket = ({ selectedBucket, bucketList, onClick }: FeedSelectBuc
       ) : (
         <>
           <CommonDivider size="sm" />
-          <ContentsWrapper>
+          <AddBucketWrapper style={{ paddingTop: '1rem' }}>
             <CommonText type="smallInfo">취미에 맞는 버킷이 없습니다!</CommonText>
-            <AddBucketButtonBox>
+            <AddBucketButtonBox onClick={() => navigate('/bucket/create')}>
               <CommonButton type="text">버킷 추가하러 가기</CommonButton>
               <CommonIcon type="chevronRight" />
             </AddBucketButtonBox>
-          </ContentsWrapper>
+          </AddBucketWrapper>
         </>
       )}
     </Container>

--- a/src/features/feed/components/FeedSelectBucket/style.tsx
+++ b/src/features/feed/components/FeedSelectBucket/style.tsx
@@ -6,10 +6,11 @@ export const Container = styled.div`
   flex-direction: column;
 `;
 
-export const ContentsWrapper = styled.div`
+export const TitleWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  padding-bottom: 1rem;
 `;
 
 export const BucketListWrapper = styled.div`
@@ -26,10 +27,18 @@ export const BucketBox = styled.div`
   gap: 0.25rem;
 `;
 
+export const AddBucketWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 1rem;
+`;
+
 export const AddBucketButtonBox = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  cursor: pointer;
 `;
 
 export const ImageInput = styled.input`

--- a/src/features/feed/components/FeedSelectBucket/style.tsx
+++ b/src/features/feed/components/FeedSelectBucket/style.tsx
@@ -4,6 +4,7 @@ import { COMMON } from '@/shared/styles/Common';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
+  height: 100%;
 `;
 
 export const TitleWrapper = styled.div`
@@ -14,10 +15,12 @@ export const TitleWrapper = styled.div`
 `;
 
 export const BucketListWrapper = styled.div`
+  height: 100%;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
-  padding: 2rem 0;
+  padding: 0.5rem 0;
+  overflow-y: auto;
 `;
 
 export const BucketBox = styled.div`

--- a/src/features/feed/service/queryOption.ts
+++ b/src/features/feed/service/queryOption.ts
@@ -7,7 +7,7 @@ const feedQueryOption = {
     hobbyName,
     nickname,
     onlyNicknameLikeFeeds,
-    sortCondition = 'RECENT',
+    sortCondition = 'recent',
     size = 5,
   }: GetFeedsRequest) =>
     infiniteQueryOptions({

--- a/src/features/item/service/types.ts
+++ b/src/features/item/service/types.ts
@@ -33,6 +33,7 @@ export interface GetMyItemsResponse {
   cursorId: string;
   summaries: MyItemSummary[];
   totalCount: number;
+  totalMemberItemCount: number;
 }
 
 export interface DeleteItemRequest {

--- a/src/features/search/components/searchItemList/index.tsx
+++ b/src/features/search/components/searchItemList/index.tsx
@@ -42,7 +42,7 @@ const SearchItemList = ({ keyword }: SearchListItemProp) => {
           {data.items.map(({ itemSummary }) => (
             <GridItem key={itemSummary.id} onClick={() => navigate(`/item/${itemSummary.id}`)}>
               <CommonImage size="sm" src={itemSummary.image} />
-              <CommonText type="normalInfo">{formatNumber(itemSummary.price)}원</CommonText>
+              <CommonText type="normalInfo">{formatNumber(itemSummary.price)}</CommonText>
               <CommonText type="smallInfo">{itemSummary.name}</CommonText>
             </GridItem>
           ))}

--- a/src/pages/Bucket/BucketCreate/index.tsx
+++ b/src/pages/Bucket/BucketCreate/index.tsx
@@ -9,7 +9,7 @@ import {
   CommonText,
   Header,
 } from '@/shared/components';
-import { useDrawer } from '@/shared/hooks';
+import { useDrawer, useValidateForm } from '@/shared/hooks';
 import { Box, ButtonWrapper, Container, Form, SelectedItemsBox, Wrapper } from './style';
 import { BucketSelectItem } from '@/features/bucket/components';
 import { useCreateBucket } from '@/features/bucket/hooks';
@@ -35,6 +35,7 @@ const BucketCreate = () => {
   const [selectedHobby, setSelectedHobby] = useState<Hobby>({ english: '', hangul: '' });
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([]);
   const createBucket = useCreateBucket();
+  const registerOptions = useValidateForm();
   const {
     register,
     handleSubmit,
@@ -123,7 +124,7 @@ const BucketCreate = () => {
                 type="text"
                 width="full"
                 error={errors.budget}
-                {...register('budget', { minLength: 1 })}
+                {...register('budget', ...registerOptions.budget)}
               />
             </Box>
           </Wrapper>

--- a/src/pages/Bucket/BucketCreate/index.tsx
+++ b/src/pages/Bucket/BucketCreate/index.tsx
@@ -65,10 +65,16 @@ const BucketCreate = () => {
         <CommonText type="normalTitle" noOfLines={0}>
           새 버킷만들기
         </CommonText>
+        <div>
+          <CommonText type="normalInfo" noOfLines={0}>
+            버킷은 나의 아이템 중에서 하나이상을 선택해서 만들 수 있어요. 아이템은 직접 추가하거나
+            아이템 담기를 통해 추가할 수 있어요.
+          </CommonText>
+        </div>
         <Form onSubmit={handleSubmit(onSubmit)}>
           <Wrapper>
             <Box>
-              <CommonText type="normalInfo" noOfLines={0}>
+              <CommonText type="normalInfo" noOfLines={1}>
                 버킷 이름
               </CommonText>
               <CommonInput

--- a/src/pages/Bucket/BucketDetail/index.tsx
+++ b/src/pages/Bucket/BucketDetail/index.tsx
@@ -60,7 +60,7 @@ const BucketDetail = () => {
               <ContentsBox key={id} onClick={() => navigate(`/item/${id}`)}>
                 <CommonImage size="sm" src={image} />
                 <CommonText type="smallInfo">{name}</CommonText>
-                <CommonText type="smallInfo">{formatNumber(price)}원</CommonText>
+                <CommonText type="smallInfo">{formatNumber(price)}</CommonText>
               </ContentsBox>
             ))}
           </ContentsWrapper>

--- a/src/pages/Bucket/BucketHome/index.tsx
+++ b/src/pages/Bucket/BucketHome/index.tsx
@@ -5,36 +5,27 @@ import {
   CommonIconButton,
   CommonTabs,
   CommonText,
-  DividerImage,
   Header,
 } from '@/shared/components';
 import { useUserInfo } from '@/shared/hooks';
-import { formatNumber } from '@/shared/utils';
-import {
-  AddButtonWrapper,
-  Container,
-  ContentsBox,
-  ContentsPanel,
-  ContentsWrapper,
-  NoResult,
-  TitleWrapper,
-} from './style';
-import { bucketQueryOption } from '@/features/bucket/service';
+import { AddButtonWrapper, Container, ContentsWrapper, TitleWrapper } from './style';
+import { BucketList } from '@/features/bucket/components';
 import { hobbyQueryOption } from '@/features/hobby/service';
 
 const BucketHome = () => {
   const { nickname } = useParams();
   const navigate = useNavigate();
   const userInfo = useUserInfo();
+  const [searchParams, setSearchParams] = useSearchParams();
   const hobby = useQuery({ ...hobbyQueryOption.all(), select: (data) => data.hobbies });
 
-  const [searchParams, setSearchParams] = useSearchParams({
-    hobby: hobby.isSuccess ? hobby.data[0].name : 'basketball',
-  });
+  if (hobby.isPending) {
+    return;
+  }
 
-  const bucket = useQuery(
-    bucketQueryOption.list({ nickname: nickname!, hobby: searchParams.get('hobby')! })
-  );
+  if (hobby.isError) {
+    return;
+  }
 
   const currentTabIndex = hobby.data
     ?.map(({ name }) => name)
@@ -46,9 +37,6 @@ const BucketHome = () => {
       <Container>
         <TitleWrapper>
           <CommonText type="normalTitle">버킷</CommonText>
-          <CommonText type="subStrongInfo">
-            총 {bucket.data?.buckets.length || 0}개의 버킷
-          </CommonText>
         </TitleWrapper>
         <CommonDivider size="sm" />
         <CommonTabs
@@ -59,37 +47,15 @@ const BucketHome = () => {
           onClick={(value) => {
             setSearchParams({ hobby: value });
           }}
-          tabsData={
-            hobby.data?.map(({ name, value }) => ({
-              value: name,
-              label: value,
-              content: (
-                <ContentsWrapper>
-                  {bucket.isSuccess && bucket.data.buckets.length > 0 ? (
-                    <ContentsPanel>
-                      {bucket.data.buckets.map((bucket) => (
-                        <ContentsBox
-                          key={bucket.bucketId}
-                          onClick={() => navigate(`./${bucket.bucketId}`)}
-                        >
-                          <DividerImage
-                            type="base"
-                            images={bucket.itemImages.map(({ imgUrl }) => imgUrl)}
-                          />
-                          <CommonText type="smallInfo">{bucket.name}</CommonText>
-                          <CommonText type="smallInfo">
-                            {formatNumber(bucket.totalPrice)}
-                          </CommonText>
-                        </ContentsBox>
-                      ))}
-                    </ContentsPanel>
-                  ) : (
-                    <NoResult>버킷이 없습니다.</NoResult>
-                  )}
-                </ContentsWrapper>
-              ),
-            })) || []
-          }
+          tabsData={hobby.data.map(({ name, value }) => ({
+            value: name,
+            label: value,
+            content: (
+              <ContentsWrapper>
+                <BucketList nickname={nickname!} hobby={name} />
+              </ContentsWrapper>
+            ),
+          }))}
         />
       </Container>
       {userInfo?.nickname === nickname && (

--- a/src/pages/Bucket/BucketHome/index.tsx
+++ b/src/pages/Bucket/BucketHome/index.tsx
@@ -78,7 +78,7 @@ const BucketHome = () => {
                           />
                           <CommonText type="smallInfo">{bucket.name}</CommonText>
                           <CommonText type="smallInfo">
-                            {formatNumber(bucket.totalPrice)}원
+                            {formatNumber(bucket.totalPrice)}
                           </CommonText>
                         </ContentsBox>
                       ))}

--- a/src/pages/Bucket/BucketHome/style.ts
+++ b/src/pages/Bucket/BucketHome/style.ts
@@ -15,31 +15,7 @@ export const TitleWrapper = styled.div`
 `;
 
 export const ContentsWrapper = styled.div`
-  height: calc(100vh - 215.91px);
-`;
-
-export const ContentsPanel = styled.div`
-  max-height: 100%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-  padding: 1rem 2rem 1rem 2rem;
-  overflow-y: auto;
-`;
-
-export const ContentsBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  cursor: pointer;
-`;
-
-export const NoResult = styled.div`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  height: calc(100vh - 10.807rem);
 `;
 
 export const AddButtonWrapper = styled.div`

--- a/src/pages/Bucket/BucketUpdate/index.tsx
+++ b/src/pages/Bucket/BucketUpdate/index.tsx
@@ -3,7 +3,7 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { CommonButton, CommonDrawer, CommonInput, CommonText, Header } from '@/shared/components';
-import { useDrawer, useUserInfo } from '@/shared/hooks';
+import { useDrawer, useUserInfo, useValidateForm } from '@/shared/hooks';
 import { Container, ContentsPanel, ContentsWrapper, Form } from './style';
 import { BucketSelectedItems, BucketUpdateItem } from '@/features/bucket/components';
 import { useUpdateBucket } from '@/features/bucket/hooks';
@@ -45,7 +45,7 @@ const BucketUpdate = () => {
       return { hobby: data.hobby, items, id: data.bucketId, name: data.name, budget: data.budget };
     },
   });
-
+  const registerOptions = useValidateForm();
   const onSubmit: SubmitHandler<BucketInfo> = (data) => {
     if (bucket.isSuccess && selectedItems.length > 0) {
       updateBucket.mutate({
@@ -109,7 +109,7 @@ const BucketUpdate = () => {
                 type="text"
                 width="full"
                 error={errors.budget}
-                {...register('budget', { minLength: 1 })}
+                {...register('budget', ...registerOptions.budget)}
               />
             </ContentsPanel>
           </ContentsWrapper>

--- a/src/pages/Feed/FeedCreate/index.tsx
+++ b/src/pages/Feed/FeedCreate/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { useQuery } from '@tanstack/react-query';
 import {
   CommonButton,
   CommonDrawer,
@@ -18,7 +17,6 @@ import {
   ButtonWrapper,
   SelectedBucketBox,
 } from './style';
-import { bucketQueryOption } from '@/features/bucket/service';
 import { FeedSelectBucket } from '@/features/feed/components';
 import { useCreateFeed } from '@/features/feed/hooks';
 import { HobbyRadio } from '@/features/hobby/components';
@@ -35,23 +33,21 @@ interface Textarea {
 const FeedCreate = () => {
   const [selectedHobby, setSelectedHobby] = useState('');
   const [selectedBucket, setSelectedBucket] = useState<SelectedBucket | null>(null);
+
+  const userInfo = useUserInfo();
+  const createFeed = useCreateFeed();
+
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
   } = useForm<Textarea>({ mode: 'onBlur' });
-  const userInfo = useUserInfo();
-
-  const createFeed = useCreateFeed();
-  const bucketList = useQuery(
-    bucketQueryOption.list({ hobby: selectedHobby, nickname: userInfo?.nickname || '' })
-  );
-
   const onSubmit: SubmitHandler<Textarea> = (data) => {
     if (selectedBucket) {
       createFeed.mutate({ bucketId: selectedBucket.id, content: data.textarea });
     }
   };
+
   const { isOpen, onOpen, onClose } = useDrawer();
 
   return (
@@ -117,10 +113,11 @@ const FeedCreate = () => {
           isDisabled={!selectedBucket}
           footerButtonText="선택 완료"
         >
-          {bucketList.data && (
+          {userInfo && (
             <FeedSelectBucket
+              hobby={selectedHobby}
+              nickname={userInfo.nickname}
               selectedBucket={selectedBucket?.id || 0}
-              bucketList={bucketList.data}
               onClick={setSelectedBucket}
             />
           )}

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -104,7 +104,9 @@ const FeedDetail = () => {
       <div>
         <CommonDivider size="lg" />
         <CommentNumberWrapper>
-          <CommonText type="normalInfo">총 {comment.data?.totalCount || 0}개의 댓글</CommonText>
+          <CommonText type="normalInfo">
+            총 {comment.data?.totalCommentCount || 0}개의 댓글
+          </CommonText>
         </CommentNumberWrapper>
         <CommonDivider size="sm" />
       </div>

--- a/src/pages/Feed/FeedDetail/index.tsx
+++ b/src/pages/Feed/FeedDetail/index.tsx
@@ -44,7 +44,7 @@ const FeedDetail = () => {
   const comment = useQuery(commentQueryQption.list({ feedId: feedIdNumber }));
 
   const { register, handleSubmit, reset, setValue } = useForm<CommentContent>();
-  const addComment = useAddComment();
+  const addComment = useAddComment(feedIdNumber);
   const onCreateComment: SubmitHandler<CommentContent> = (data) => {
     addComment.mutate({ feedId: feedIdNumber, content: data.content });
     reset();

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -42,7 +42,7 @@ const FeedHome = () => {
 
                   setSearchParams({
                     hobby: searchParams.get('hobby') || '',
-                    sort: sort.toUpperCase(),
+                    sort: sort,
                   });
                 }}
               />

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -37,8 +37,10 @@ const CommonButton = ({
   isLike,
 }: CommonButtonProps) => {
   const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.stopPropagation();
-    onClick && onClick();
+    if (onClick) {
+      e.stopPropagation();
+      onClick();
+    }
   };
 
   const button = {

--- a/src/shared/components/DividerImage/index.tsx
+++ b/src/shared/components/DividerImage/index.tsx
@@ -70,7 +70,13 @@ const DividerImage = ({ images, type }: DividerImageProps) => {
                   : undefined
               }
             >
-              <Image src={image} width="100%" height="100%" objectFit="cover" />
+              <Image
+                src={image}
+                width="100%"
+                height="100%"
+                objectFit="cover"
+                fallbackSrc="https://placehold.co/300?text=Bucket+Back&font=roboto"
+              />
             </GridItem>
           );
         })}

--- a/src/shared/hooks/useValidateForm.tsx
+++ b/src/shared/hooks/useValidateForm.tsx
@@ -50,6 +50,15 @@ const useValidateForm = () => {
         },
       },
     ],
+    budget: [
+      {
+        minLength: 1,
+        pattern: {
+          value: /^[0-9]*$/g,
+          message: '숫자만 입력해주세요.',
+        },
+      },
+    ],
   };
 
   return registerOptions;


### PR DESCRIPTION
## 구현(수정) 내용
버킷 관련 무한 스크롤을 구현했습니다.
- 버킷 페이지
- 피드 생성시 버킷 목록

QA를 반영했습니다.
- 버킷 예산에 숫자만 입력 가능하게 수정
- 댓글 작성중 레벨이 오를 경우 피드 상세 내용이 갱신 안되는 오류 수정
- 버킷 생성에 설명 추가
- 피드 상세의 아이템 목록에 가격 추가
- 기본 이미지 추가
- 멤버 페이지의 피드 navigate 수정
- 피드 페이지 정렬 선택 오류 수정
- 좋아요, 좋아요 취소 수정

totalCount관련 새로운 api 명세를 반영했습니다.

formatNumber 유틸함수에 원이 추가되어 기존에 원이 작성된 부분 수정했습니다.

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
