### PR TITLE
[OMCT-397] QA 반영 및 디자인 수정

### DIFF
--- a/src/features/comment/components/CommentItem/index.tsx
+++ b/src/features/comment/components/CommentItem/index.tsx
@@ -42,6 +42,7 @@ const CommentItem = ({
           nickname={memberInfo.nickName}
           levelNumber={memberInfo.level}
           isAdopted={isAdopted}
+          imageSize="2.5rem"
         />
         {userInfo?.nickname === memberInfo.nickName && (
           <CommonMenu type="update" iconSize="0.25rem" onDelete={onDelete} onUpdate={onUpdate} />

--- a/src/features/feed/components/FeedItem/style.tsx
+++ b/src/features/feed/components/FeedItem/style.tsx
@@ -37,7 +37,7 @@ export const DetailInfoWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 0.5rem;
+  padding: 0.5rem 0.5rem 0 0.5rem;
 `;
 
 export const InteractPanel = styled.div`

--- a/src/features/feed/components/FeedMemberContents/style.ts
+++ b/src/features/feed/components/FeedMemberContents/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  height: calc(100vh - 12.75rem);
+  height: calc(100vh - 13rem);
   overflow-y: auto;
 `;
 

--- a/src/features/item/components/ItemList/index.tsx
+++ b/src/features/item/components/ItemList/index.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { CommonImage, CommonText } from '@/shared/components';
 import { ellipsisName, formatNumber } from '@/shared/utils';
 import { PositionWrapper, ItemListWrapper, ImageInput, ImageLabel } from './style';
+import { ImageBorder } from '@/shared/styles/ImageBorder';
 import { ItemSummary } from '@/shared/types/item';
 
 interface ItemListProps {
@@ -37,7 +38,9 @@ const ListItem = ({
       <ItemListWrapper>
         <ImageInput type="checkbox" id={String(id)} onChange={() => handleChange(id)} />
         <ImageLabel htmlFor={String(id)}>
-          <CommonImage size="sm" src={image} />
+          <ImageBorder>
+            <CommonImage size="sm" src={image} />
+          </ImageBorder>
         </ImageLabel>
         <CommonText type="normalInfo">{formatNumber(price)}</CommonText>
         <CommonText type="smallInfo" noOfLines={0}>
@@ -48,7 +51,9 @@ const ListItem = ({
   ) : (
     <PositionWrapper>
       <ItemListWrapper onClick={handleClick}>
-        <CommonImage size="sm" alt={name} src={image} />
+        <ImageBorder>
+          <CommonImage size="sm" alt={name} src={image} />
+        </ImageBorder>
         <CommonText type="normalInfo">{formatNumber(price)}</CommonText>
         <CommonText type="smallInfo" noOfLines={0}>
           {ellipsisName(name, 20)}

--- a/src/features/member/components/MemberEditForm/style.ts
+++ b/src/features/member/components/MemberEditForm/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Form = styled.form`
-  height: 90%;
+  height: 93%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -31,7 +31,8 @@ export const ButtonWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  gap: 1rem;
+  gap: 0.75rem;
+  padding: 1rem 0;
 `;
 
 export const FileInput = styled.input`

--- a/src/pages/Bucket/BucketCreate/index.tsx
+++ b/src/pages/Bucket/BucketCreate/index.tsx
@@ -21,6 +21,7 @@ import {
 import { BucketSelectItem } from '@/features/bucket/components';
 import { useCreateBucket } from '@/features/bucket/hooks';
 import { HobbySelector } from '@/features/hobby/components';
+import { ImageBorder } from '@/shared/styles/ImageBorder';
 
 interface Hobby {
   english: string;
@@ -110,15 +111,16 @@ const BucketCreate = () => {
                   />
                 ) : (
                   selectedItems.map(({ id, src }) => (
-                    <CommonImage
-                      key={id}
-                      size="sm"
-                      src={src}
-                      onClick={() => {
-                        onOpen();
-                        setSelectedItems([]);
-                      }}
-                    />
+                    <ImageBorder key={id}>
+                      <CommonImage
+                        size="sm"
+                        src={src}
+                        onClick={() => {
+                          onOpen();
+                          setSelectedItems([]);
+                        }}
+                      />
+                    </ImageBorder>
                   ))
                 )}
               </SelectedItemsBox>

--- a/src/pages/Bucket/BucketCreate/style.ts
+++ b/src/pages/Bucket/BucketCreate/style.ts
@@ -46,5 +46,5 @@ export const SelectedItemsBox = styled.div`
   flex-wrap: wrap;
   gap: 0.3rem;
   overflow-y: auto;
-  height: 6.5rem;
+  height: 6.6rem;
 `;

--- a/src/pages/Feed/FeedDetail/style.tsx
+++ b/src/pages/Feed/FeedDetail/style.tsx
@@ -12,7 +12,7 @@ export const CommentsContainer = styled.div`
 `;
 
 export const CommentNumberWrapper = styled.div`
-  padding: 1rem 1.75rem;
+  padding: 0.75rem 1.75rem;
 `;
 
 export const CommentInputContainer = styled.form`

--- a/src/pages/Feed/FeedHome/index.tsx
+++ b/src/pages/Feed/FeedHome/index.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { CommonSelect, CommonTabs } from '@/shared/components';
+import { CommonDivider, CommonSelect, CommonTabs } from '@/shared/components';
 import { Container, SelectWrapper } from './style';
 import { FeedHomeList } from '@/features/feed/components';
 import { hobbyQueryOption } from '@/features/hobby/service';
@@ -47,6 +47,7 @@ const FeedHome = () => {
                 }}
               />
             </SelectWrapper>
+            <CommonDivider size="sm" />
             <FeedHomeList
               hobbyName={searchParams.get('hobby') || hobbies.data[0].name}
               sortCondition={searchParams.get('sort') || 'recent'}

--- a/src/pages/Feed/FeedHome/style.tsx
+++ b/src/pages/Feed/FeedHome/style.tsx
@@ -16,6 +16,7 @@ export const NoResult = styled.div`
 export const SelectWrapper = styled.div`
   display: flex;
   justify-content: end;
-  padding-top: 1rem;
+  padding-top: 0.5rem;
   padding-right: 1.5rem;
+  padding-bottom: 0.75rem;
 `;

--- a/src/pages/Item/Detail/index.tsx
+++ b/src/pages/Item/Detail/index.tsx
@@ -25,6 +25,7 @@ import { ItemComment } from '@/features/item/components';
 import { useTakeItem } from '@/features/item/hooks';
 import { itemQueryOption } from '@/features/item/service';
 import { reviewQueryOption } from '@/features/review/service';
+import { ImageBorder } from '@/shared/styles/ImageBorder';
 
 const ItemDetail = () => {
   // 로그인 시 리뷰 클릭이 가능하도록 하기
@@ -78,9 +79,9 @@ const ItemDetail = () => {
     <>
       <Header type="back" />
       <Container>
-        <div>
+        <ImageBorder>
           <CommonImage size="md" src={data.itemInfo.image} alt={data.itemInfo.name} />
-        </div>
+        </ImageBorder>
         <ItemWrapper>
           <CommonText type="normalTitle" noOfLines={0}>
             {data.itemInfo.name}

--- a/src/pages/Member/MemberEdit/style.tsx
+++ b/src/pages/Member/MemberEdit/style.tsx
@@ -3,4 +3,5 @@ import styled from '@emotion/styled';
 export const Container = styled.div`
   height: 100%;
   padding: 0 3.5rem;
+  overflow-y: auto;
 `;

--- a/src/pages/Member/MemberHome/index.tsx
+++ b/src/pages/Member/MemberHome/index.tsx
@@ -28,6 +28,7 @@ import {
   Grid,
   IconBox,
   AddBox,
+  ContentsContainer,
 } from './style';
 import { useLeave, useLogout } from '@/features/member/hooks';
 import { memberQueryOption } from '@/features/member/service';
@@ -87,7 +88,7 @@ const MemberHome = () => {
           </CommonText>
         </MemberIntroWrapper>
         <CommonDivider size="lg" />
-        <div style={{ height: '100%', overflowY: 'scroll' }}>
+        <ContentsContainer>
           <ContentsWrapper onClick={() => navigate(`/member/${nickname}/inventory`)}>
             <ContentsPanel>
               <div>
@@ -175,7 +176,7 @@ const MemberHome = () => {
             </ContentsPanel>
           </ContentsWrapper>
           <CommonDivider size="sm" />
-        </div>
+        </ContentsContainer>
       </Container>
       <Footer />
 

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -30,7 +30,7 @@ export const MemberInfoBox = styled.div`
 
 export const MemberIntroWrapper = styled.div`
   display: flex;
-  padding: 1.5rem 3.5rem;
+  padding: 1rem 3.5rem;
 `;
 
 export const ContentsContainer = styled.div`

--- a/src/pages/Member/MemberHome/style.tsx
+++ b/src/pages/Member/MemberHome/style.tsx
@@ -33,6 +33,11 @@ export const MemberIntroWrapper = styled.div`
   padding: 1.5rem 3.5rem;
 `;
 
+export const ContentsContainer = styled.div`
+  height: 100%;
+  overflow-y: auto;
+`;
+
 export const ContentsWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -64,7 +69,7 @@ export const Grid = styled.div`
 `;
 
 export const IconBox = styled.div`
-  padding-right: 0.75rem;
+  padding-right: 0.3rem;
 `;
 
 export const AddBox = styled.div`

--- a/src/pages/Search/SearchHome/style.tsx
+++ b/src/pages/Search/SearchHome/style.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const HeaderBox = styled.div``;
 
 export const Container = styled.div`
-  height: 100%;
+  height: 108%;
   overflow: hidden;
 `;
 

--- a/src/shared/components/Avatar/index.tsx
+++ b/src/shared/components/Avatar/index.tsx
@@ -25,7 +25,7 @@ const CommonAvatar = ({
     <>
       {isOwner ? (
         <Box position="relative" width="8em">
-          <Avatar src={src} width="8rem" height="8rem" />
+          <Avatar border="1px solid #e2e8f0" src={src} width="8rem" height="8rem" />
           <Circle
             size="8"
             bg="gray.100"
@@ -42,7 +42,14 @@ const CommonAvatar = ({
         </Box>
       ) : (
         <Box>
-          <Avatar src={src} width={size} height={size} onClick={handleClick} cursor="pointer" />
+          <Avatar
+            border="1px solid #e2e8f0"
+            src={src}
+            width={size}
+            height={size}
+            onClick={handleClick}
+            cursor="pointer"
+          />
         </Box>
       )}
     </>

--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -120,6 +120,8 @@ const CommonButton = ({
     sm: (
       <Button
         size="sm"
+        fontSize="0.75rem"
+        height="1.75rem"
         colorScheme="blue"
         variant="outline"
         borderColor="blue.300"

--- a/src/shared/components/Profile/index.tsx
+++ b/src/shared/components/Profile/index.tsx
@@ -7,9 +7,10 @@ interface ProfileProps {
   nickname: string;
   levelNumber: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
   isAdopted?: boolean;
+  imageSize?: string;
 }
 
-const Profile = ({ nickname, src, levelNumber, isAdopted }: ProfileProps) => {
+const Profile = ({ nickname, src, levelNumber, isAdopted, imageSize = '3rem' }: ProfileProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -18,7 +19,7 @@ const Profile = ({ nickname, src, levelNumber, isAdopted }: ProfileProps) => {
 
   return (
     <Flex alignItems="center">
-      <CommonAvatar isOwner={false} size="3rem" onClick={handleClick} src={src} />
+      <CommonAvatar isOwner={false} size={imageSize} onClick={handleClick} src={src} />
       <Box ml="0.8rem" onClick={handleClick} cursor="pointer">
         <CommonText type="normalInfo" weight={700} color="blue.900" noOfLines={1}>
           {nickname}

--- a/src/shared/components/Profile/index.tsx
+++ b/src/shared/components/Profile/index.tsx
@@ -20,7 +20,7 @@ const Profile = ({ nickname, src, levelNumber, isAdopted }: ProfileProps) => {
     <Flex alignItems="center">
       <CommonAvatar isOwner={false} size="3rem" onClick={handleClick} src={src} />
       <Box ml="0.8rem" onClick={handleClick} cursor="pointer">
-        <CommonText type="smallTitle" color="blue.900" noOfLines={1}>
+        <CommonText type="normalInfo" weight={700} color="blue.900" noOfLines={1}>
           {nickname}
         </CommonText>
         <HStack spacing="0.25rem">

--- a/src/shared/components/Text/index.tsx
+++ b/src/shared/components/Text/index.tsx
@@ -8,17 +8,18 @@ interface CommonTextProps {
   noOfLines?: number | number[];
   children: ReactNode;
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  weight?: 700 | 600 | 500 | 400;
 }
 
 const TEXT_TYPE = {
   strongTitle: { fontSize: '3rem' },
   normalTitle: { fontSize: '1.5rem' },
   smallTitle: { fontSize: '1.25rem' },
-  strongInfo: { fontSize: '1rem', weight: 700 },
-  subStrongInfo: { fontSize: '1.125rem', weight: 400 },
-  normalInfo: { fontSize: '0.875rem', weight: 500 },
-  boldNormalInfo: { fontSize: '0.75rem', weight: 600 },
-  smallInfo: { fontSize: '0.75rem', weight: 400 },
+  strongInfo: { fontSize: '1rem' },
+  subStrongInfo: { fontSize: '1.125rem' },
+  normalInfo: { fontSize: '0.875rem' },
+  boldNormalInfo: { fontSize: '0.75rem' },
+  smallInfo: { fontSize: '0.75rem' },
 };
 
 const CommonText = ({
@@ -27,6 +28,7 @@ const CommonText = ({
   noOfLines = 1,
   as = 'h2',
   children,
+  weight,
 }: CommonTextProps) => {
   return (
     <>
@@ -35,7 +37,7 @@ const CommonText = ({
           {children}
         </Text>
       ) : (
-        <Text color={color} noOfLines={noOfLines} {...TEXT_TYPE[type]}>
+        <Text color={color} noOfLines={noOfLines} {...TEXT_TYPE[type]} fontWeight={weight}>
           {children}
         </Text>
       )}


### PR DESCRIPTION
## 구현(수정) 내용
QA 반영 및 디자인을 수정했습니다.
- 멤버 페이지의 디자인을 수정
- Profile 컴포넌트의 닉네임 글자 크기 수정
- 이미지에 border 추가
- 비밀번호 변경 페이지 스크롤 생성
- 피드 상세 페이지 디자인 수정

## 스크린샷
![스크린샷 2023-12-02 오후 3 49 52](https://github.com/bucket-back/bucket-back-frontend/assets/40534414/245f0608-24d5-4835-98d2-982502597c21)

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
