### PR TITLE
[OMCT-392] qa반영 + 무한스크롤

### DIFF
--- a/src/features/inventory/components/InventorySelectItem/index.tsx
+++ b/src/features/inventory/components/InventorySelectItem/index.tsx
@@ -68,7 +68,7 @@ const InventorySelectItem = ({
                 onChange={(e) => handleChange(e, itemInfo.image)}
               />
               <ImageLabel htmlFor={String(itemInfo.id)}>
-                <CommonImage size="sm" src={itemInfo.image} />
+                <CommonImage size="sm" src={itemInfo.image} border="1px solid #e2e8f0 " />
               </ImageLabel>
               <CommonText type="smallInfo">{formatNumber(itemInfo.price)}</CommonText>
               <CommonText type="smallInfo">{itemInfo.name}</CommonText>

--- a/src/features/inventory/service/queryOption.ts
+++ b/src/features/inventory/service/queryOption.ts
@@ -1,12 +1,17 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import { GetInventoryDetailRequest, GetInventoryItemsRequest, inventoryApi } from '.';
 
 const inventoryQueryOption = {
   all: ['inventory'] as const,
-  myItems: ({ inventoryId, hobbyName, cursorId, size = 10 }: GetInventoryItemsRequest) =>
-    queryOptions({
+  myItems: ({ inventoryId, hobbyName, size = 10 }: GetInventoryItemsRequest) =>
+    infiniteQueryOptions({
       queryKey: [...inventoryQueryOption.all, inventoryId, hobbyName] as const,
-      queryFn: () => inventoryApi.getInventoryItems({ inventoryId, hobbyName, cursorId, size }),
+      queryFn: ({ pageParam: cursorId }) =>
+        inventoryApi.getInventoryItems({ inventoryId, hobbyName, cursorId, size }),
+      initialPageParam: '',
+      getNextPageParam: ({ nextCursorId }) => {
+        return nextCursorId;
+      },
     }),
   list: (nickname: string) =>
     queryOptions({

--- a/src/features/member/components/MemberNicknameForm/index.tsx
+++ b/src/features/member/components/MemberNicknameForm/index.tsx
@@ -10,9 +10,10 @@ import { submitValue } from '@/pages/Member/Signup';
 interface MemberNicknameFormProps {
   setSubmitValue: React.Dispatch<React.SetStateAction<submitValue>>;
   nickname: string;
+  submitValue: submitValue;
 }
 
-const MemberNicknameForm = ({ setSubmitValue, nickname }: MemberNicknameFormProps) => {
+const MemberNicknameForm = ({ setSubmitValue, nickname, submitValue }: MemberNicknameFormProps) => {
   const {
     register,
     formState: { errors },
@@ -25,7 +26,7 @@ const MemberNicknameForm = ({ setSubmitValue, nickname }: MemberNicknameFormProp
   } = useCheckNickname();
 
   const handleCheckNickname = () => {
-    if (errors.nickname || !nickname) {
+    if (errors.nickname || !nickname || nickname === submitValue.nickname) {
       return;
     }
     checkNicknameMutate(nickname);

--- a/src/features/vote/components/VoteSelectItem/index.tsx
+++ b/src/features/vote/components/VoteSelectItem/index.tsx
@@ -64,7 +64,7 @@ const VoteSelectItem = ({ selectedItems, onChange, selectedHobby }: VoteSelectIt
               />
 
               <ImageLabel htmlFor={String(itemInfo.id)}>
-                <CommonImage size="sm" src={itemInfo.image} />
+                <CommonImage size="sm" src={itemInfo.image} border="1px solid #e2e8f0 " />
               </ImageLabel>
               <CommonText type="normalInfo">{formatNumber(itemInfo.price)}</CommonText>
               <CommonText type="smallInfo">{itemInfo.name}</CommonText>

--- a/src/features/vote/hooks/useCreateVote.ts
+++ b/src/features/vote/hooks/useCreateVote.ts
@@ -8,7 +8,7 @@ const useCreateVote = () => {
   return useMutation({
     mutationFn: voteApi.postVotes,
     onSuccess: (data) => {
-      navigate(`/vote/${data.voteId}`);
+      navigate(`/vote/${data.voteId}`, { replace: true });
     },
   });
 };

--- a/src/pages/Inventory/InventoryCreate/index.tsx
+++ b/src/pages/Inventory/InventoryCreate/index.tsx
@@ -74,6 +74,7 @@ const InventoryCreate = () => {
                 {selectedItems.map(({ id, src }) => (
                   <GridItem key={id}>
                     <CommonImage
+                      border="1px solid #e2e8f0 "
                       src={src}
                       size="sm"
                       onClick={() => {

--- a/src/pages/Inventory/InventoryDetail/index.tsx
+++ b/src/pages/Inventory/InventoryDetail/index.tsx
@@ -43,7 +43,7 @@ const InventoryDetail = () => {
         <Grid>
           {inventoryDetailData?.inventoryItemInfos.map(({ image, name, price, id }, index) => (
             <GridItem key={index} onClick={() => navigate(`/item/${id}`)}>
-              <CommonImage size="sm" src={image} />
+              <CommonImage size="sm" src={image} border="1px solid #e2e8f0 " />
               <CommonText type="smallInfo">{name}</CommonText>
               <CommonText type="smallInfo">{formatNumber(price)}</CommonText>
             </GridItem>

--- a/src/pages/Member/Login/index.tsx
+++ b/src/pages/Member/Login/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { CommonButton, CommonIcon, CommonInput } from '@/shared/components';
+import { CommonButton, CommonIcon, CommonInput, Header } from '@/shared/components';
 import { useValidateForm } from '@/shared/hooks';
 import { ButtonWrapper, Container, Form, IconWrapper, InputWrapper } from './style';
 import { useLogin } from '@/features/member/hooks';
@@ -23,44 +23,47 @@ const Login = () => {
   };
 
   return (
-    <Container>
-      <Form onSubmit={handleSubmit(onSubmit)}>
-        <InputWrapper>
-          <CommonInput
-            type="text"
-            label="이메일"
-            placeholder="이메일을 입력해주세요."
-            error={errors.email}
-            {...register('email', ...registerOptions.email)}
-          />
-          <CommonInput
-            type={showPassword ? 'text' : 'password'}
-            label="비밀번호"
-            placeholder="비밀번호를 입력해주세요."
-            error={errors.password}
-            rightIcon={
-              <IconWrapper onClick={() => setShowPassword(() => !showPassword)}>
-                <CommonIcon type={showPassword ? 'eye' : 'eyeSlash'} size="1.25rem" />
-              </IconWrapper>
-            }
-            {...register('password', { required: '비밀번호를 입력해주세요.' })}
-          />
-        </InputWrapper>
-        <ButtonWrapper>
-          <CommonButton type="mdMiddle" isSubmit={true}>
-            로그인
-          </CommonButton>
-          <CommonButton
-            type="mdMiddle"
-            onClick={() => {
-              navigate('/signup');
-            }}
-          >
-            회원가입
-          </CommonButton>
-        </ButtonWrapper>
-      </Form>
-    </Container>
+    <>
+      <Header type="back" />
+      <Container>
+        <Form onSubmit={handleSubmit(onSubmit)}>
+          <InputWrapper>
+            <CommonInput
+              type="text"
+              label="이메일"
+              placeholder="이메일을 입력해주세요."
+              error={errors.email}
+              {...register('email', ...registerOptions.email)}
+            />
+            <CommonInput
+              type={showPassword ? 'text' : 'password'}
+              label="비밀번호"
+              placeholder="비밀번호를 입력해주세요."
+              error={errors.password}
+              rightIcon={
+                <IconWrapper onClick={() => setShowPassword(() => !showPassword)}>
+                  <CommonIcon type={showPassword ? 'eye' : 'eyeSlash'} size="1.25rem" />
+                </IconWrapper>
+              }
+              {...register('password', { required: '비밀번호를 입력해주세요.' })}
+            />
+          </InputWrapper>
+          <ButtonWrapper>
+            <CommonButton type="mdMiddle" isSubmit={true}>
+              로그인
+            </CommonButton>
+            <CommonButton
+              type="mdMiddle"
+              onClick={() => {
+                navigate('/signup');
+              }}
+            >
+              회원가입
+            </CommonButton>
+          </ButtonWrapper>
+        </Form>
+      </Container>
+    </>
   );
 };
 

--- a/src/pages/Member/Signup/index.tsx
+++ b/src/pages/Member/Signup/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
-import { CommonButton } from '@/shared/components';
+import { CommonButton, Header } from '@/shared/components';
 import { useCustomToast } from '@/shared/hooks';
 import { Container, Form, InputWrapper } from './style';
 import MemberEmailForm from '@/features/member/components/MemberEmailForm';
@@ -35,6 +35,7 @@ const SignUp = () => {
 
   return (
     <FormProvider {...methods}>
+      <Header type="back" />
       <Container>
         <Form onSubmit={methods.handleSubmit(onSubmit)}>
           <InputWrapper>
@@ -48,7 +49,11 @@ const SignUp = () => {
             <MemberPassword />
           </InputWrapper>
           <InputWrapper>
-            <MemberNicknameForm setSubmitValue={setSubmitValue} nickname={nickname} />
+            <MemberNicknameForm
+              setSubmitValue={setSubmitValue}
+              nickname={nickname}
+              submitValue={submitValue}
+            />
           </InputWrapper>
           <CommonButton type="mdFull" isSubmit={true}>
             회원가입

--- a/src/shared/components/Image/index.tsx
+++ b/src/shared/components/Image/index.tsx
@@ -5,6 +5,7 @@ interface CommonImageProps {
   src?: ImageProps['src'];
   alt?: ImageProps['alt'];
   onClick?: () => void;
+  border?: string;
 }
 
 const IMAGE_SIZE = {
@@ -16,7 +17,7 @@ const IMAGE_SIZE = {
   xl: { width: '20.1875rem', aspectRatio: '323/264' },
 };
 
-const CommonImage = ({ size, alt, src, onClick }: CommonImageProps) => {
+const CommonImage = ({ size, alt, src, onClick, border }: CommonImageProps) => {
   const handleClick = () => {
     onClick && onClick();
   };
@@ -32,6 +33,7 @@ const CommonImage = ({ size, alt, src, onClick }: CommonImageProps) => {
       borderRadius={size === 'xs' ? 'full' : '0.625rem'}
       fallbackSrc="https://placehold.co/800?text=Bucket+Back&font=roboto"
       onClick={handleClick}
+      border={border}
     />
   );
 };


### PR DESCRIPTION
## 구현(수정) 내용
1. 투표 생성시 취미에 맞는 아이템을 가져올때 무한스크롤을 적용하였습니다
2. 인벤토리 생성시 리뷰한 아이템을 가져올때 무한스크롤을 적용하였습니다.
3. 투표 생성후 뒤로가기했을때 투표목록으로 이동합니다.
4. 이미지에 border를 추가하였습니다.
5. 로그인, 회원가입페이지에 뒤로가기를 넣었습니다.
6. 닉네임 중복버튼을 클릭했을시 같은 닉네임을 입력했을 경우 api호출이 안되도록 막아두었습니다.

## 스크린샷

<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
