### PR TITLE
[OMCT-405] 인벤토리, 투표 생성페이지 중복코드 삭제

### DIFF
--- a/src/pages/Inventory/InventoryCreate/index.tsx
+++ b/src/pages/Inventory/InventoryCreate/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CommonButton, CommonDrawer, Header } from '@/shared/components';
+import { CommonButton, CommonDrawer, CommonText, Header } from '@/shared/components';
 import { useCustomToast, useDrawer } from '@/shared/hooks';
 import { Container, CreateWrapper } from './style';
 import InventorySelectItem from '@/features/inventory/components/InventorySelectItem';
@@ -40,6 +40,9 @@ const InventoryCreate = () => {
       <Header type="back" />
       <Container>
         <CreateWrapper>
+          <CommonText type="normalTitle" noOfLines={0}>
+            인벤토리 생성하기
+          </CommonText>
           <CreateTemplate
             setSelectedHobby={setSelectedHobby}
             selectedHobby={selectedHobby}

--- a/src/pages/Inventory/InventoryCreate/index.tsx
+++ b/src/pages/Inventory/InventoryCreate/index.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { CommonButton, CommonDrawer, CommonImage, CommonText, Header } from '@/shared/components';
+import { CommonButton, CommonDrawer, Header } from '@/shared/components';
 import { useCustomToast, useDrawer } from '@/shared/hooks';
-import { Box, Container, Grid, GridItem, RadioBox, Wrapper } from './style';
-import HobbySelector from '@/features/hobby/components/HobbySelector';
+import { Container, CreateWrapper } from './style';
 import InventorySelectItem from '@/features/inventory/components/InventorySelectItem';
 import { useCreateInventory } from '@/features/inventory/hook';
 import { SelectedItem } from '@/features/inventory/service';
+import CreateTemplate from '@/shared/components/CreateTemplate';
 
 interface Hobby {
   english: string;
@@ -39,62 +39,25 @@ const InventoryCreate = () => {
     <>
       <Header type="back" />
       <Container>
-        <Wrapper>
-          <Box>
-            <CommonText type="normalTitle" noOfLines={0}>
-              인벤토리 생성하기
-            </CommonText>
-          </Box>
-          <Box>
-            <CommonText type="normalInfo" noOfLines={0}>
-              취미별 인벤토리를 생성할 수 있습니다.
-            </CommonText>
-            <CommonText type="normalInfo" noOfLines={0}>
-              취미를 선택해주세요.
-            </CommonText>
-            <RadioBox>
-              <HobbySelector onChange={setSelectedHobby} />
-            </RadioBox>
-          </Box>
-          <Box>
-            <CommonText type="normalInfo" noOfLines={0}>
-              리뷰한 아이템을 선택해주세요.
-            </CommonText>
-            {selectedItems.length < 1 ? (
-              <CommonButton
-                type="custom"
-                onClick={() => {
-                  !selectedHobby.english
-                    ? openToast({ type: 'info', message: '취미를 선택해주세요.' })
-                    : onOpen();
-                }}
-              />
-            ) : (
-              <Grid>
-                {selectedItems.map(({ id, src }) => (
-                  <GridItem key={id}>
-                    <CommonImage
-                      src={src}
-                      size="sm"
-                      onClick={() => {
-                        onOpen();
-                        setSelectedItems([]);
-                      }}
-                    />
-                  </GridItem>
-                ))}
-              </Grid>
-            )}
-          </Box>
-        </Wrapper>
-
-        <CommonButton
-          type="mdFull"
-          onClick={onSubmit}
-          isDisabled={!selectedHobby || !selectedItems.length}
-        >
-          생성 완료
-        </CommonButton>
+        <CreateWrapper>
+          <CreateTemplate
+            setSelectedHobby={setSelectedHobby}
+            selectedHobby={selectedHobby}
+            selectedItems={selectedItems}
+            setSelectedItems={setSelectedItems}
+            onOpen={onOpen}
+            type="inventory"
+          />
+        </CreateWrapper>
+        <div>
+          <CommonButton
+            type="mdFull"
+            onClick={onSubmit}
+            isDisabled={!selectedHobby || !selectedItems.length}
+          >
+            생성 완료
+          </CommonButton>
+        </div>
       </Container>
       <CommonDrawer
         isOpen={isOpen}

--- a/src/pages/Inventory/InventoryCreate/style.ts
+++ b/src/pages/Inventory/InventoryCreate/style.ts
@@ -14,3 +14,8 @@ export const CreateWrapper = styled.div`
   flex-direction: column;
   gap: 1.5rem;
 `;
+
+export const Wrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/pages/Inventory/InventoryCreate/style.ts
+++ b/src/pages/Inventory/InventoryCreate/style.ts
@@ -9,36 +9,8 @@ export const Container = styled.main`
   height: 100%;
 `;
 
-export const Box = styled.article`
+export const CreateWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-`;
-
-export const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-`;
-
-export const RadioBox = styled.div`
-  overflow-x: auto;
-`;
-
-export const SelectedItems = styled.div`
-  display: flex;
-  gap: 0.5rem;
-`;
-
-export const Grid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-`;
-
-export const GridItem = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-bottom: 1rem;
+  gap: 1.5rem;
 `;

--- a/src/pages/Vote/VoteCreate/index.tsx
+++ b/src/pages/Vote/VoteCreate/index.tsx
@@ -1,30 +1,19 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import {
-  CommonButton,
-  CommonDrawer,
-  CommonImage,
-  CommonText,
-  CommonTextarea,
-  Header,
-} from '@/shared/components';
+import { CommonButton, CommonDrawer, CommonTextarea, Header } from '@/shared/components';
 import { useCustomToast, useDrawer } from '@/shared/hooks';
-import { FormContainer, Wrapper, TextareaWrapper, RadioBox, SelectedItems } from './style';
-import HobbySelector from '@/features/hobby/components/HobbySelector';
-import { SelectedItem } from '@/features/inventory/service';
+import { SelectedHobby, SelectedItem } from '@/shared/types';
+import { FormContainer, TextareaWrapper } from './style';
 import { VoteSelectItem } from '@/features/vote/components';
 import { useCreateVote } from '@/features/vote/hooks';
+import CreateTemplate from '@/shared/components/CreateTemplate';
 
 interface Textarea {
   textarea: string;
 }
-interface Hobby {
-  english: string;
-  hangul: string;
-}
 
 const VoteCreate = () => {
-  const [selectedHobby, setSelectedHobby] = useState<Hobby>({ english: '', hangul: '' });
+  const [selectedHobby, setSelectedHobby] = useState<SelectedHobby>({ english: '', hangul: '' });
   const [prevSelectedHobby, setPrevSelectedHobby] = useState<string>('');
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([]);
   const { mutate: CreateVoteMutate } = useCreateVote();
@@ -56,48 +45,14 @@ const VoteCreate = () => {
     <>
       <Header type="back" />
       <FormContainer onSubmit={handleSubmit(onSubmit)}>
-        <Wrapper>
-          <CommonText type="normalTitle" noOfLines={0}>
-            투표 생성하기
-          </CommonText>
-        </Wrapper>
-        <Wrapper>
-          <CommonText type="normalInfo" noOfLines={0}>
-            취미를 선택해주세요.
-          </CommonText>
-          <RadioBox>
-            <HobbySelector onChange={setSelectedHobby} />
-          </RadioBox>
-        </Wrapper>
-        <Wrapper>
-          <CommonText type="normalInfo" noOfLines={0}>
-            아이템을 두개 선택해주세요.
-          </CommonText>
-          {selectedItems.length <= 1 ? (
-            <CommonButton
-              type="custom"
-              onClick={() => {
-                !selectedHobby.english
-                  ? openToast({ type: 'info', message: '취미를 선택해주세요.' })
-                  : onOpen();
-              }}
-            />
-          ) : (
-            <SelectedItems>
-              {selectedItems.map(({ id, src }) => (
-                <CommonImage
-                  key={id}
-                  src={src}
-                  size="sm"
-                  onClick={() => {
-                    onOpen();
-                    setSelectedItems([]);
-                  }}
-                />
-              ))}
-            </SelectedItems>
-          )}
-        </Wrapper>
+        <CreateTemplate
+          setSelectedHobby={setSelectedHobby}
+          selectedHobby={selectedHobby}
+          selectedItems={selectedItems}
+          setSelectedItems={setSelectedItems}
+          onOpen={onOpen}
+          type="vote"
+        />
         <TextareaWrapper>
           <CommonTextarea
             placeholder="투표 내용을 입력해주세요."

--- a/src/pages/Vote/VoteCreate/index.tsx
+++ b/src/pages/Vote/VoteCreate/index.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { CommonButton, CommonDrawer, CommonTextarea, Header } from '@/shared/components';
+import {
+  CommonButton,
+  CommonDrawer,
+  CommonText,
+  CommonTextarea,
+  Header,
+} from '@/shared/components';
 import { useCustomToast, useDrawer } from '@/shared/hooks';
 import { SelectedHobby, SelectedItem } from '@/shared/types';
 import { FormContainer, TextareaWrapper } from './style';
@@ -45,6 +51,11 @@ const VoteCreate = () => {
     <>
       <Header type="back" />
       <FormContainer onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <CommonText type="normalTitle" noOfLines={0}>
+            투표 생성하기
+          </CommonText>
+        </div>
         <CreateTemplate
           setSelectedHobby={setSelectedHobby}
           selectedHobby={selectedHobby}

--- a/src/pages/Vote/VoteCreate/style.ts
+++ b/src/pages/Vote/VoteCreate/style.ts
@@ -9,24 +9,9 @@ export const FormContainer = styled.form`
   height: 100%;
 `;
 
-export const Wrapper = styled.article`
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-`;
-
 export const TextareaWrapper = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-`;
-
-export const RadioBox = styled.div`
-  overflow-x: auto;
-`;
-
-export const SelectedItems = styled.div`
-  display: flex;
-  gap: 0.5rem;
 `;

--- a/src/shared/components/CreateTemplate/index.tsx
+++ b/src/shared/components/CreateTemplate/index.tsx
@@ -23,10 +23,6 @@ const CreateTemplate = ({
   type,
 }: CreateTemplateProps) => {
   const openToast = useCustomToast();
-  const title = {
-    vote: '투표',
-    inventory: '인벤토리',
-  };
 
   const selection = {
     vote: '아이템을 두개 선택해주세요.',
@@ -35,11 +31,6 @@ const CreateTemplate = ({
 
   return (
     <>
-      <Wrapper>
-        <CommonText type="normalTitle" noOfLines={0}>
-          {title[type]} 생성하기
-        </CommonText>
-      </Wrapper>
       <Wrapper>
         <CommonText type="normalInfo" noOfLines={0}>
           {type === 'inventory' && (

--- a/src/shared/components/CreateTemplate/index.tsx
+++ b/src/shared/components/CreateTemplate/index.tsx
@@ -1,0 +1,91 @@
+import { Dispatch, SetStateAction } from 'react';
+import { CommonText, CommonButton, CommonImage } from '@/shared/components';
+import { useCustomToast } from '@/shared/hooks';
+import { SelectedHobby, SelectedItem } from '@/shared/types';
+import { Grid, GridItem, RadioBox, Wrapper } from './style';
+import { HobbySelector } from '@/features/hobby/components';
+
+interface CreateTemplateProps {
+  selectedHobby: SelectedHobby;
+  setSelectedHobby: Dispatch<SetStateAction<SelectedHobby>>;
+  selectedItems: SelectedItem[];
+  setSelectedItems: Dispatch<SetStateAction<SelectedItem[]>>;
+  onOpen: () => void;
+  type: 'vote' | 'inventory';
+}
+
+const CreateTemplate = ({
+  setSelectedHobby,
+  selectedHobby,
+  selectedItems,
+  setSelectedItems,
+  onOpen,
+  type,
+}: CreateTemplateProps) => {
+  const openToast = useCustomToast();
+  const title = {
+    vote: '투표',
+    inventory: '인벤토리',
+  };
+
+  const selection = {
+    vote: '아이템을 두개 선택해주세요.',
+    inventory: '리뷰한 아이템을 선택해주세요.',
+  };
+
+  return (
+    <>
+      <Wrapper>
+        <CommonText type="normalTitle" noOfLines={0}>
+          {title[type]} 생성하기
+        </CommonText>
+      </Wrapper>
+      <Wrapper>
+        <CommonText type="normalInfo" noOfLines={0}>
+          {type === 'inventory' && (
+            <>
+              취미별 인벤토리를 생성할 수 있습니다.
+              <br />
+            </>
+          )}
+          취미를 선택해주세요.
+        </CommonText>
+        <RadioBox>
+          <HobbySelector onChange={setSelectedHobby} />
+        </RadioBox>
+      </Wrapper>
+      <Wrapper>
+        <CommonText type="normalInfo" noOfLines={0}>
+          {selection[type]}
+        </CommonText>
+        {selectedItems.length < 1 ? (
+          <CommonButton
+            type="custom"
+            onClick={() => {
+              !selectedHobby.english
+                ? openToast({ type: 'info', message: '취미를 선택해주세요.' })
+                : onOpen();
+            }}
+          />
+        ) : (
+          <Grid>
+            {selectedItems.map(({ id, src }) => (
+              <GridItem key={id}>
+                <CommonImage
+                  src={src}
+                  size="sm"
+                  onClick={() => {
+                    onOpen();
+                    setSelectedItems([]);
+                  }}
+                />
+              </GridItem>
+            ))}
+          </Grid>
+        )}
+      </Wrapper>
+    </>
+  );
+};
+
+export default CreateTemplate;

--- a/src/shared/components/CreateTemplate/style.ts
+++ b/src/shared/components/CreateTemplate/style.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+`;
+
+export const RadioBox = styled.div`
+  overflow-x: auto;
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+`;
+
+export const GridItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+`;

--- a/src/shared/types/hobby.ts
+++ b/src/shared/types/hobby.ts
@@ -2,3 +2,8 @@ export interface Hobby {
   name: string;
   value: string;
 }
+
+export interface SelectedHobby {
+  english: string;
+  hangul: string;
+}

--- a/src/shared/types/item.ts
+++ b/src/shared/types/item.ts
@@ -28,3 +28,8 @@ export interface MyItemSummary {
   cursorId: string;
   itemInfo: ItemInfo;
 }
+
+export interface SelectedItem {
+  id: number;
+  src: string;
+}


### PR DESCRIPTION
## 구현(수정) 내용
인벤토리, 투표 생성페이지 중복코드 삭제했습니다.
취미를 선택하고 아이템을 선택하는 부분을 공통으로 하였습니다.
아직 인벤토리와 투표만 적용했고 공통스타일 적용도 아직입니다.
## 스크린샷
![image](https://github.com/bucket-back/bucket-back-frontend/assets/104294861/f33d067c-0a7d-4aa8-8950-c50a878f127d)
![image](https://github.com/bucket-back/bucket-back-frontend/assets/104294861/2085faed-648f-4b69-9e16-7a3ca19fa8a3)


## PR 포인트 및 궁금한 점

<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->
