### PR TITLE
[NO-JIRA] 리프레시 토큰 로직 구현

### DIFF
--- a/src/core/service/axios.ts
+++ b/src/core/service/axios.ts
@@ -1,12 +1,8 @@
 import axios, { AxiosError, isAxiosError } from 'axios';
 import { ERRORCODE, TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
 import { Storage } from '@/shared/utils';
+import { ResponseData } from './types';
 import { memberApi } from '@/features/member/service';
-interface ResponseData {
-  error: string;
-  code: string;
-  message: string;
-}
 
 const BASE_ENDPOINT_URL = import.meta.env.VITE_ENDPOINT_URL;
 
@@ -38,12 +34,12 @@ axiosClient.interceptors.request.use(
 
 axiosClient.interceptors.response.use(
   (response) => response,
-  async (error: AxiosError) => {
+  async (error: AxiosError<ResponseData>) => {
     if (!isAxiosError(error)) {
       return Promise.reject(error);
     }
 
-    const { code } = error.response?.data as ResponseData;
+    const { code } = error.response!.data;
 
     const { config } = error;
 

--- a/src/core/service/axios.ts
+++ b/src/core/service/axios.ts
@@ -1,22 +1,20 @@
 import axios, { AxiosError, isAxiosError } from 'axios';
-import { TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
-import { useCustomToast } from '@/shared/hooks';
+import { ERRORCODE, TOKEN_KEY, USER_INFO_KEY } from '@/shared/constants';
 import { Storage } from '@/shared/utils';
 import { memberApi } from '@/features/member/service';
-import { OpenToastProps } from '@/shared/hooks/useCustomToast';
+interface ResponseData {
+  error: string;
+  code: string;
+  message: string;
+}
 
 const BASE_ENDPOINT_URL = import.meta.env.VITE_ENDPOINT_URL;
 
-const redirectionLocation = (
-  removeStorage: string[],
-  href: string,
-  openToast: ({ message, type }: OpenToastProps) => void
-) => {
+const redirectionLocation = (removeStorage: string[], href: string) => {
   if (removeStorage.length >= 1) {
     removeStorage.forEach((removeKey) => Storage.removeLocalStoraged(removeKey));
   }
   window.location.href = href;
-  openToast({ message: '다시 로그인 해주세요!', type: 'error' });
 };
 
 export const axiosClient = axios.create({
@@ -30,7 +28,7 @@ axiosClient.interceptors.request.use(
     const token = Storage.getLocalStoraged(TOKEN_KEY);
 
     if (token?.trim().length) {
-      config.headers.Authorization = `Bearer ${token}`;
+      config.headers.set('Authorization', `Bearer ${token}`);
     }
 
     return config;
@@ -45,31 +43,29 @@ axiosClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    console.log('refresh 시작');
+    const { code } = error.response?.data as ResponseData;
 
-    const { code, config } = error;
-    const openToast = useCustomToast();
+    const { config } = error;
 
     switch (code) {
-      case 'COMMON_011': {
+      case ERRORCODE.COMMON_008: {
         try {
-          const accessToken = await memberApi.postRefresh();
+          const data = await memberApi.postRefresh();
 
-          Storage.removeLocalStoraged(TOKEN_KEY);
-
-          accessToken && Storage.setLocalStoraged(TOKEN_KEY, accessToken);
+          if (data.accessToken) {
+            config?.headers.set('Authorization', `Bearer ${data.accessToken}`);
+            Storage.setLocalStoraged(TOKEN_KEY, data.accessToken);
+          }
 
           return axios(config!);
         } catch (error) {
-          console.log('refresh 요청을 했지만 실패');
-          redirectionLocation([TOKEN_KEY, USER_INFO_KEY], 'login', openToast);
+          redirectionLocation([TOKEN_KEY, USER_INFO_KEY], 'login');
         }
         break;
       }
-      case 'COMMON_012':
-      case 'COMMON_013': {
-        console.log('refresh 토큰이 만료 / 토큰이 유효하지 않는 경우 실패');
-        redirectionLocation([TOKEN_KEY, USER_INFO_KEY], 'login', openToast);
+      case ERRORCODE.COMMON_012:
+      case ERRORCODE.COMMON_013: {
+        redirectionLocation([TOKEN_KEY, USER_INFO_KEY], 'login');
         break;
       }
     }

--- a/src/core/service/types.ts
+++ b/src/core/service/types.ts
@@ -1,0 +1,5 @@
+export interface ResponseData {
+  error: string;
+  code: string;
+  message: string;
+}

--- a/src/features/member/service/handler.ts
+++ b/src/features/member/service/handler.ts
@@ -8,6 +8,7 @@ import {
   PutMemberImageRequest,
   PutMemberRequest,
 } from './types';
+
 import { axiosClient } from '@/core/service/axios';
 
 const BASE_URL = 'members';
@@ -36,6 +37,14 @@ const memberApi = {
       email,
       password,
     });
+
+    return response.data;
+  },
+
+  postRefresh: async () => {
+    const url = `${BASE_URL}/refresh`;
+
+    const response = await axiosClient.post<Pick<PostLoginResponse, 'accessToken'>>(url);
 
     return response.data;
   },

--- a/src/shared/constants/errorCode.ts
+++ b/src/shared/constants/errorCode.ts
@@ -1,0 +1,7 @@
+const ERRORCODE = {
+  COMMON_008: 'COMMON_008',
+  COMMON_012: 'COMMON_012',
+  COMMON_013: 'COMMON_013',
+};
+
+export default ERRORCODE;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,3 @@
 export * from './storage';
 export * from './path';
-export * from './errorCode';
+export { default as ERRORCODE } from './errorCode';

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './storage';
 export * from './path';
+export * from './errorCode';


### PR DESCRIPTION
## 구현(수정) 내용
refresh,access 토큰 만료 시 **axios interceptor**를 활용해서 각 상황에 따라 로직 처리

- ### access 토큰 만료시
    - 기존 로그인 시 발급 했던 access 토큰을 활용해서 다시 요청 handler 추가
    - 새로 발급 받은 access 토큰을 헤더에 추가 및 localstorage 다시 설정
    - axios단에서 다시 재요청 추가

- ### refresh 토큰 만료시
    - redirection하여서 다시 로그인 페이지로 이동 및 localstorage 삭제

## 스크린샷
- ### access 토큰 만료시
<img width="1286" alt="스크린샷 2024-02-17 오후 4 47 43" src="https://github.com/bucket-back/bucket-back-frontend/assets/78207432/08526315-b73f-4829-bda2-47ff84fcbe47">

- **refresh 토큰 만료시는 바로 페이지가 이동해서 스크린 샷은 못 찍었습니다!**

## PR 포인트 및 궁금한 점